### PR TITLE
Pythonize release workflows and use ls-remote for origin consistency

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -23,7 +23,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: main
-          fetch-tags: true
 
       - name: Setup Python
         uses: ./.github/actions/setup-python

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -15,76 +15,17 @@ permissions:
 jobs:
   hotfix:
     runs-on: ubuntu-latest
-    env:
-      BASE_VERSION: ${{ inputs.base_version }}
     steps:
-      - name: Normalise and validate version
-        run: |
-          BASE_VERSION="${BASE_VERSION#v}"
-          echo "BASE_VERSION=${BASE_VERSION}" >> $GITHUB_ENV
-          if [[ ! "${BASE_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Version must be in semver format (e.g., 1.3.0 or v1.3.0)"
-            exit 1
-          fi
-
-      - name: Check base release tag exists
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if ! gh api "repos/${{ github.repository }}/git/ref/tags/v${BASE_VERSION}" --silent 2>/dev/null; then
-            echo "::error::Release tag v${BASE_VERSION} does not exist — can only hotfix a finalised release"
-            exit 1
-          fi
-
       - name: Checkout from base release tag
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: v${{ inputs.base_version }}
           fetch-depth: 0
 
-      - name: Determine hotfix version
-        id: hotfix
-        run: |
-          MAJOR=$(echo "${BASE_VERSION}" | cut -d. -f1)
-          MINOR=$(echo "${BASE_VERSION}" | cut -d. -f2)
-          PATCH=$(echo "${BASE_VERSION}" | cut -d. -f3)
+      - name: Setup Python
+        uses: ./.github/actions/setup-python
 
-          HIGHEST_PATCH=$PATCH
-          while true; do
-            NEXT_PATCH=$((HIGHEST_PATCH + 1))
-            if git ls-remote --tags origin "refs/tags/v${MAJOR}.${MINOR}.${NEXT_PATCH}" | grep -q . || \
-               git ls-remote --tags origin "refs/tags/v${MAJOR}.${MINOR}.${NEXT_PATCH}-rc.*" | grep -q .; then
-              HIGHEST_PATCH=$NEXT_PATCH
-            else
-              break
-            fi
-          done
-
-          HOTFIX_VERSION="${MAJOR}.${MINOR}.$((HIGHEST_PATCH + 1))"
-          echo "version=$HOTFIX_VERSION" >> $GITHUB_OUTPUT
-          echo "Hotfix version: $HOTFIX_VERSION"
-
-      - name: Create hotfix release branch
-        run: |
-          BRANCH="release/${{ steps.hotfix.outputs.version }}"
-          if git ls-remote --heads origin "${BRANCH}" | grep -q .; then
-            echo "::error::Branch ${BRANCH} already exists"
-            exit 1
-          fi
-          git checkout -b "${BRANCH}"
-          git push origin "${BRANCH}"
-
-      - name: Summary
-        run: |
-          HOTFIX_VERSION="${{ steps.hotfix.outputs.version }}"
-          echo "## Hotfix Branch Created" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **Hotfixing:** v${BASE_VERSION}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Hotfix version:** ${HOTFIX_VERSION}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Branch:** release/${HOTFIX_VERSION}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Branched from:** v${BASE_VERSION} ($(git rev-parse HEAD))" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Next steps" >> $GITHUB_STEP_SUMMARY
-          echo "1. Push your fix to \`release/${HOTFIX_VERSION}\` (directly or via PR)" >> $GITHUB_STEP_SUMMARY
-          echo "2. Run **Tag New RC** (from branch \`release/${HOTFIX_VERSION}\`) with version \`${HOTFIX_VERSION}\` to start promotion" >> $GITHUB_STEP_SUMMARY
-          echo "3. After prod deployment, the merge-back issue will be created automatically" >> $GITHUB_STEP_SUMMARY
+      - name: Create hotfix
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: uv run invoke release.hotfix --base-version "${{ inputs.base_version }}"

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -20,7 +20,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: v${{ inputs.base_version }}
-          fetch-depth: 0
 
       - name: Setup Python
         uses: ./.github/actions/setup-python

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -20,42 +20,21 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.normalise.outputs.version }}
-    env:
-      VERSION: ${{ inputs.version }}
+      version: ${{ steps.validate.outputs.version }}
     steps:
-      - name: Normalise and validate RC tag format
-        id: normalise
-        run: |
-          if [[ "${VERSION}" =~ ^[0-9] ]]; then
-            VERSION="v${VERSION}"
-          fi
-          if [[ ! "${VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
-            echo "::error::Version must be an RC tag (e.g., v1.2.0-rc.1 or 1.2.0-rc.1)"
-            exit 1
-          fi
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
 
-      - name: Validate tag exists
+      - name: Setup Python
+        uses: ./.github/actions/setup-python
+
+      - name: Validate promotion
+        id: validate
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          VERSION="${{ steps.normalise.outputs.version }}"
-          if ! gh api "repos/${{ github.repository }}/git/ref/tags/${VERSION}" --silent 2>/dev/null; then
-            echo "::error::Tag ${VERSION} does not exist"
-            exit 1
-          fi
-
-      - name: Validate tag is on a release branch
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          VERSION="${{ steps.normalise.outputs.version }}"
-          BRANCH_VERSION=$(echo "${VERSION}" | sed 's/^v//; s/-rc\.[0-9]*//')
-          if ! gh api "repos/${{ github.repository }}/branches/release%2F${BRANCH_VERSION}" --silent 2>/dev/null; then
-            echo "::error::No release branch release/${BRANCH_VERSION} found for tag ${VERSION}. Tags must belong to a release branch."
-            exit 1
-          fi
+        run: uv run invoke release.validate-promotion --version "${{ inputs.version }}"
 
   deploy-test:
     needs: validate
@@ -81,144 +60,17 @@ jobs:
   finalise:
     needs: [validate, deploy-prod]
     runs-on: ubuntu-latest
-    env:
-      VERSION: ${{ needs.validate.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ needs.validate.outputs.version }}
-          fetch-depth: 0
+          ref: main
+          fetch-tags: true
 
-      - name: Determine final version
-        id: final
-        run: |
-          FINAL_VERSION=$(echo "${VERSION}" | sed 's/-rc\.[0-9]*//')
-          echo "version=$FINAL_VERSION" >> $GITHUB_OUTPUT
-          echo "Final version: $FINAL_VERSION"
+      - name: Setup Python
+        uses: ./.github/actions/setup-python
 
-      - name: Create final release tag
-        run: |
-          FINAL="${{ steps.final.outputs.version }}"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          if git rev-parse "${FINAL}" >/dev/null 2>&1; then
-            echo "Tag ${FINAL} already exists — skipping tag creation"
-          else
-            git tag -a "${FINAL}" -m "Release ${FINAL}"
-            git push origin "${FINAL}"
-          fi
-
-      - name: Find previous stable release
-        id: prev
+      - name: Finalise promotion
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          FINAL="${{ steps.final.outputs.version }}"
-          # Find the previous stable release tag (not pre-release, not current)
-          PREV=$(gh release list --exclude-drafts --exclude-pre-releases \
-            --json tagName --jq '.[].tagName' \
-            | grep -v "^${FINAL}$" \
-            | head -1)
-          echo "previous=${PREV}" >> $GITHUB_OUTPUT
-          if [[ -n "${PREV}" ]]; then
-            echo "Previous stable release: ${PREV}"
-          else
-            echo "No previous stable release found"
-          fi
-
-      - name: Publish stable GitHub Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          FINAL="${{ steps.final.outputs.version }}"
-          PREV="${{ steps.prev.outputs.previous }}"
-          if gh release view "${FINAL}" --json isDraft --jq '.isDraft' 2>/dev/null | grep -q true; then
-            echo "Deleting draft release ${FINAL}"
-            gh release delete "${FINAL}" --yes
-          fi
-          if gh release view "${FINAL}" 2>/dev/null | grep -q .; then
-            echo "Release ${FINAL} already exists — skipping"
-          else
-            if [[ -n "${PREV}" ]]; then
-              echo "Creating stable release ${FINAL} with notes from ${PREV}"
-              NOTES=$(gh api "repos/${{ github.repository }}/releases/generate-notes" \
-                -f tag_name="${FINAL}" \
-                -f previous_tag_name="${PREV}" \
-                --jq '.body')
-              gh release create "${FINAL}" \
-                --title "${FINAL}" \
-                --notes "${NOTES}" \
-                --latest
-            else
-              echo "Creating stable release ${FINAL} (first release)"
-              gh release create "${FINAL}" \
-                --title "${FINAL}" \
-                --generate-notes \
-                --latest
-            fi
-          fi
-
-      - name: Determine release branch
-        id: branch
-        run: |
-          BRANCH_VERSION=$(echo "${VERSION}" | sed 's/^v//; s/-rc\.[0-9]*//')
-          echo "name=release/${BRANCH_VERSION}" >> $GITHUB_OUTPUT
-
-      - name: Check for merge-back need
-        id: mergeback
-        run: |
-          BRANCH="${{ steps.branch.outputs.name }}"
-          AHEAD=$(git rev-list --count origin/main..origin/${BRANCH})
-          echo "ahead=$AHEAD" >> $GITHUB_OUTPUT
-          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
-          if [[ "$AHEAD" -eq 0 ]]; then
-            echo "Release branch has no new commits — no merge-back needed"
-            echo "needed=false" >> $GITHUB_OUTPUT
-          else
-            echo "Release branch is $AHEAD commit(s) ahead of main — merge-back required"
-            echo "needed=true" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Annotate GitHub Release with merge-back note
-        if: steps.mergeback.outputs.needed == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          FINAL="${{ steps.final.outputs.version }}"
-          AHEAD="${{ steps.mergeback.outputs.ahead }}"
-          BRANCH="${{ steps.mergeback.outputs.branch }}"
-          EXISTING_NOTES=$(gh release view "${FINAL}" --json body --jq '.body')
-          MERGE_NOTE="---"
-          MERGE_NOTE="${MERGE_NOTE}\n\n⚠️ **Merge-back required:** This release has ${AHEAD} commit(s) on \`${BRANCH}\` that are not on \`main\`. See the merge-back issue for instructions."
-          gh release edit "${FINAL}" \
-            --notes "$(echo -e "${EXISTING_NOTES}\n\n${MERGE_NOTE}")"
-
-      - name: Create merge-back issue
-        if: steps.mergeback.outputs.needed == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          FINAL="${{ steps.final.outputs.version }}"
-          AHEAD="${{ steps.mergeback.outputs.ahead }}"
-          BRANCH="${{ steps.mergeback.outputs.branch }}"
-          MERGE_VERSION="${FINAL#v}"
-          gh issue create \
-            --title "Merge back: ${FINAL}" \
-            --body "$(echo -e "Release **${FINAL}** has ${AHEAD} commit(s) on \`${BRANCH}\` that need merging back to \`main\`.\n\n## Steps\n\n\`\`\`bash\ngit fetch origin\ngit checkout main\ngit pull origin main\ngit checkout -b merge-back/${MERGE_VERSION}\ngit merge origin/${BRANCH}\n# Resolve conflicts if any\ngit push origin merge-back/${MERGE_VERSION}\n\`\`\`\n\nThen open a PR from \`merge-back/${MERGE_VERSION}\` to \`main\`:\n\nhttps://github.com/${{ github.repository }}/compare/main...merge-back/${MERGE_VERSION}?expand=1\n\nClose this issue once the PR is merged.")"
-
-      - name: Summary
-        run: |
-          FINAL="${{ steps.final.outputs.version }}"
-          echo "## Release Finalised" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **Release:** ${FINAL} (stable — visible on Releases page)" >> $GITHUB_STEP_SUMMARY
-          echo "- **From RC:** ${VERSION}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Releases page now shows" >> $GITHUB_STEP_SUMMARY
-          echo "- **${FINAL}** — Latest (stable release)" >> $GITHUB_STEP_SUMMARY
-          echo "- Previous pre-releases show the RC history" >> $GITHUB_STEP_SUMMARY
-          if [[ "${{ steps.mergeback.outputs.needed }}" == "true" ]]; then
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "⚠️ **Merge-back required** — ${{ steps.mergeback.outputs.ahead }} commit(s) need merging to main. See issue." >> $GITHUB_STEP_SUMMARY
-          fi
+        run: uv run invoke release.finalise-promotion --version "${{ needs.validate.outputs.version }}"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -65,7 +65,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: main
-          fetch-tags: true
 
       - name: Setup Python
         uses: ./.github/actions/setup-python

--- a/.github/workflows/tag-rc.yml
+++ b/.github/workflows/tag-rc.yml
@@ -20,7 +20,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: release/${{ inputs.version }}
-          fetch-depth: 0
 
       - name: Setup Python
         uses: ./.github/actions/setup-python

--- a/.github/workflows/tag-rc.yml
+++ b/.github/workflows/tag-rc.yml
@@ -15,92 +15,17 @@ permissions:
 jobs:
   tag-rc:
     runs-on: ubuntu-latest
-    env:
-      VERSION: ${{ inputs.version }}
     steps:
-      - name: Normalise and validate version
-        run: |
-          VERSION="${VERSION#v}"
-          echo "VERSION=${VERSION}" >> $GITHUB_ENV
-          if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Version must be in semver format (e.g., 1.2.0 or v1.2.0)"
-            exit 1
-          fi
-
-      - name: Check release branch exists
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if ! gh api "repos/${{ github.repository }}/branches/release%2F${VERSION}" --silent 2>/dev/null; then
-            echo "::error::Branch release/${VERSION} does not exist. Cut a release first."
-            exit 1
-          fi
-
-      - name: Check release is not already finalised
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if gh api "repos/${{ github.repository }}/git/ref/tags/v${VERSION}" --silent 2>/dev/null; then
-            echo "::error::Release v${VERSION} is already finalised. Use the Hotfix workflow to create a patch release instead."
-            exit 1
-          fi
-
       - name: Checkout release branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: release/${{ inputs.version }}
           fetch-depth: 0
 
-      - name: Determine next RC number
-        id: next-rc
-        run: |
-          HIGHEST=$(git ls-remote --tags origin "refs/tags/v${VERSION}-rc.*" \
-            | awk '{print $2}' \
-            | sed "s|refs/tags/v${VERSION}-rc.||" \
-            | sort -n \
-            | tail -1)
-          if [[ -z "$HIGHEST" ]]; then
-            NEXT=1
-          else
-            NEXT=$((HIGHEST + 1))
-          fi
-          TAG="v${VERSION}-rc.${NEXT}"
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
-          echo "Next RC tag: $TAG"
+      - name: Setup Python
+        uses: ./.github/actions/setup-python
 
-      - name: Create RC tag
-        run: |
-          git tag "${{ steps.next-rc.outputs.tag }}"
-          git push origin "${{ steps.next-rc.outputs.tag }}"
-
-      - name: Publish pre-release
+      - name: Tag RC
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release create "${{ steps.next-rc.outputs.tag }}" \
-            --title "${{ steps.next-rc.outputs.tag }}" \
-            --target "release/${VERSION}" \
-            --generate-notes \
-            --prerelease
-
-      - name: Trigger promotion pipeline
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh workflow run promote.yml --ref "release/${VERSION}" -f "version=${{ steps.next-rc.outputs.tag }}"
-
-      - name: Summary
-        run: |
-          echo "## New RC Tagged" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **Tag:** ${{ steps.next-rc.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Pre-release:** ${{ steps.next-rc.outputs.tag }} (published)" >> $GITHUB_STEP_SUMMARY
-          echo "- **Branch:** release/${VERSION}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Commit:** $(git rev-parse HEAD)" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Next steps" >> $GITHUB_STEP_SUMMARY
-          echo "1. The **Promote** workflow has been triggered automatically — check the Actions tab" >> $GITHUB_STEP_SUMMARY
-          echo "2. Any previous promote run for this release will be cancelled automatically" >> $GITHUB_STEP_SUMMARY
-          echo "3. Test will deploy automatically. Approve **preprod** and **prod** when prompted" >> $GITHUB_STEP_SUMMARY
-          echo "4. If another problem is found, fix it on \`release/${VERSION}\` and run **Tag New RC** again" >> $GITHUB_STEP_SUMMARY
-          echo "5. Check the **Releases** page — the new pre-release is visible" >> $GITHUB_STEP_SUMMARY
+        run: uv run invoke release.tag-rc --version "${{ inputs.version }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,18 +4,65 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-A reference implementation of **Candidate E** — a release management workflow system built entirely on GitHub Actions. It implements trunk-based development with release branches, using GitHub's Releases page as the single source of truth for deployment state (pre-releases show RC promotion history, stable releases show what's in production).
+A reference implementation of **Candidate E** — a release management workflow system built on GitHub Actions + Python. It implements trunk-based development with release branches, using GitHub's Releases page as the single source of truth for deployment state (pre-releases show RC promotion history, stable releases show what's in production).
 
-There is no application code, build system, or test suite. The entire project is GitHub Actions workflows, environment config files, and documentation.
+The repo has two layers: GitHub Actions workflows (YAML) that orchestrate the pipeline, and a Python package (`release_tools`) that implements the core release logic called by those workflows via invoke tasks.
+
+## Development Commands
+
+The project uses `uv` for Python dependency management. All commands run through `uv run`:
+
+```bash
+# Install dependencies
+uv sync
+
+# Lint
+uv run ruff check src/ tasks/ tests/
+uv run ruff format --check src/ tasks/ tests/
+
+# Type check
+uv run ty check src/ tasks/
+
+# Unit tests
+uv run pytest tests/unit/
+
+# Run a single test file
+uv run pytest tests/unit/release_tools/test_cut_release.py
+
+# Validate workflow YAML syntax
+uv run actionlint .github/workflows/*.yml
+
+# Run the cut-release task locally (requires .env with GH_TOKEN)
+uv run invoke release.cut-release --version 1.2.0
+```
+
+Pre-commit hooks run automatically on commit (ruff, actionlint, gitleaks, etc.). The `no-commit-to-branch` hook blocks direct commits to `main`.
 
 ## Repository Layout
 
-- `.github/workflows/` — The five workflow files that implement the release pipeline
+- `src/release_tools/` — Python package implementing release logic (version parsing, git operations, GitHub API calls)
+- `tasks/` — Invoke task definitions that wire up the Python classes for CLI/CI use
+- `tests/unit/` — Unit tests (pytest) for the `release_tools` package
+- `.github/workflows/` — Seven workflow files implementing the release pipeline and CI
+- `.github/actions/` — Composite actions: `setup-python` (uv + deps) and `code-quality` (ruff + ty + pytest)
 - `environments/` — Per-environment JSON config (`test.json`, `preprod.json`, `prod.json`) with container versions
 - `VERSION` — Current version number
-- `README.md` — Comprehensive usage guide with scenarios and state diagrams
 
-## Workflow Architecture
+## Code Architecture
+
+### Python Package (`src/release_tools/`)
+
+The `cut-release.yml` workflow delegates to Python via `uv run invoke release.cut-release`. The Python code is structured as:
+
+- `CutRelease` — orchestrator: parses version, validates it's higher than latest, checks no release is in-flight, then creates branch + tag + pre-release + triggers promote
+- `GitHelper` — wraps `gitpython` for branch/tag operations and querying release state (latest stable tag, in-flight releases)
+- `GitHubHelper` — wraps `PyGithub` for creating pre-releases and triggering the promote workflow
+- `ReleaseVersionHelper` — semver parsing/validation using the `semver` library
+- `GitHubActionsHelper` — detects CI vs local execution (controls where `GH_TOKEN` comes from)
+
+The invoke task in `tasks/release.py` wires these together: on GitHub Actions it reads `GH_TOKEN` and `GITHUB_REPOSITORY` from the environment; locally it loads from `.env` and derives the repo name from the git remote.
+
+### Workflow Architecture
 
 The release pipeline flows: **Cut → Promote → Finalise**, with an optional **Tag RC** loop for fixes.
 
@@ -27,15 +74,15 @@ tag-rc.yml ──────────────┘  (re-enters promotion a
 hotfix.yml ──→ creates isolated patch branch from a stable tag
 ```
 
-### Workflows
-
 | Workflow | Trigger | Purpose |
 |---|---|---|
-| `cut-release.yml` | Manual dispatch | Creates `release/X.Y.0` branch + `vX.Y.0-rc.1` tag + pre-release, then triggers promote |
+| `cut-release.yml` | Manual dispatch | Calls Python to create `release/X.Y.0` branch + `vX.Y.0-rc.1` tag + pre-release, then triggers promote |
 | `promote.yml` | Triggered by cut-release or tag-rc | Deploys RC through test→preprod→prod with approval gates, then finalises (creates stable tag + release, detects merge-back needs) |
 | `tag-rc.yml` | Manual dispatch from release branch | Auto-increments RC number, creates new pre-release, restarts promotion pipeline |
 | `hotfix.yml` | Manual dispatch from main | Creates `release/X.Y.Z` (Z>0) branch from a stable tag for isolated fixes |
 | `deploy.yml` | Called by promote.yml (reusable) | Reads environment config and simulates deployment to a single environment |
+| `main.yml` | Push to main | Runs code quality checks (ruff, ty, pytest) |
+| `pr.yml` | Pull requests | Runs the same code quality checks as main |
 
 ### Key Design Decisions
 
@@ -44,14 +91,5 @@ hotfix.yml ──→ creates isolated patch branch from a stable tag
 - **RC auto-increment**: `tag-rc.yml` uses `git ls-remote --tags` to find the highest existing RC number and increments by 1.
 - **Merge-back detection**: After finalising, the pipeline counts commits on the release branch not on main (`git rev-list --count`). If any exist, it annotates the release and creates a GitHub issue with merge-back instructions.
 - **Version validation**: All workflows validate semver format (`^[0-9]+\.[0-9]+\.[0-9]+$`) and guard against duplicate releases, missing branches, and already-finalised versions.
-
-## Working With This Repo
-
-Since this is a workflow-only repository, development means editing YAML workflows and testing them by running the GitHub Actions manually (workflow_dispatch). There are no local build, lint, or test commands.
-
-To validate workflow syntax locally, use `actionlint` if available:
-```
-actionlint .github/workflows/*.yml
-```
-
-Environment promotion requires GitHub Environment protection rules configured on the repository (preprod and prod need required reviewers). See the README "Setup" section for configuration steps.
+- **In-flight guard**: `CutRelease` checks for existing release branches without a matching final tag and blocks concurrent releases.
+- **Ruff config**: `ALL` rules enabled with specific ignores; `T201` (print) allowed since print is used intentionally for workflow output.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,6 @@
+- Test Cut Release
+- Pythonize Promote
+- Pythonize Tag RC
+- Pythonize Hotfix
+- Transfer to Account
+- Raise PR

--- a/src/release_tools/finalise_promotion.py
+++ b/src/release_tools/finalise_promotion.py
@@ -1,0 +1,104 @@
+"""Finalise promotion command."""
+
+import os
+from pathlib import Path
+
+from release_tools.git import GitHelper
+from release_tools.github import GitHubHelper
+from release_tools.version import ReleaseVersionHelper
+
+
+class FinalisePromotion:
+    """Command to finalise a promoted RC into a stable release."""
+
+    _BOT_NAME = "github-actions[bot]"
+    _BOT_EMAIL = "github-actions[bot]@users.noreply.github.com"
+
+    def __init__(self, git: GitHelper, github: GitHubHelper, raw_version: str) -> None:
+        """Initialise with helpers and the RC tag string."""
+        self._git = git
+        self._github = github
+        self._raw_version = raw_version
+
+    def run(self) -> None:
+        """Orchestrate finalising a promoted RC into a stable release.
+
+        1. Parse the RC tag and derive the final version
+        2. Create the annotated final tag
+        3. Find the previous stable release for changelog
+        4. Publish the stable GitHub Release
+        5. Detect merge-back need and create issue if required
+        6. Write a step summary
+        """
+        version = ReleaseVersionHelper.parse_rc(self._raw_version)
+        rc_tag = f"v{version}"
+        base_version = f"{version.major}.{version.minor}.{version.patch}"
+        final_tag = f"v{base_version}"
+        branch = f"release/{base_version}"
+
+        print(f"Finalising {rc_tag} as {final_tag}...")
+
+        self._git.configure_identity(self._BOT_NAME, self._BOT_EMAIL)
+
+        created = self._git.create_final_tag(final_tag, rc_tag)
+        if created:
+            print(f"  Created tag {final_tag}")
+        else:
+            print(f"  Tag {final_tag} already exists — skipped")
+
+        previous_tag = self._github.find_previous_stable_release(final_tag)
+        if previous_tag:
+            print(f"  Previous stable release: {previous_tag}")
+        else:
+            print("  No previous stable release found")
+
+        self._github.publish_stable_release(final_tag, previous_tag)
+        print(f"  Published release {final_tag}")
+
+        ahead_count = self._github.get_mergeback_count(branch)
+
+        if ahead_count > 0:
+            print(
+                f"  Release branch is {ahead_count} commit(s)"
+                " ahead of main — merge-back required"
+            )
+            self._github.annotate_release_with_mergeback(final_tag, branch, ahead_count)
+            self._github.create_mergeback_issue(final_tag, branch, ahead_count)
+            print("  Created merge-back issue")
+        else:
+            print("  No merge-back needed")
+
+        self._write_summary(final_tag, rc_tag, ahead_count, branch)
+
+    @staticmethod
+    def _write_summary(
+        final_tag: str,
+        rc_tag: str,
+        ahead_count: int,
+        branch: str,
+    ) -> None:
+        """Write the finalisation summary to step summary or stdout."""
+        summary = (
+            "## Release Finalised\n"
+            "\n"
+            f"- **Release:** {final_tag}"
+            " (stable \u2014 visible on Releases page)\n"
+            f"- **From RC:** {rc_tag}\n"
+            "\n"
+            "### Releases page now shows\n"
+            f"- **{final_tag}** \u2014 Latest (stable release)\n"
+            "- Previous pre-releases show the RC history\n"
+        )
+        if ahead_count > 0:
+            summary += (
+                "\n"
+                f"\u26a0\ufe0f **Merge-back required** \u2014"
+                f" {ahead_count} commit(s) on `{branch}` need"
+                " merging to main. See issue.\n"
+            )
+        summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+        if summary_path:
+            with Path(summary_path).open("a") as fh:
+                fh.write(summary)
+        else:
+            print(summary)

--- a/src/release_tools/git.py
+++ b/src/release_tools/git.py
@@ -15,16 +15,41 @@ class GitHelper:
         """Initialise with a git repo."""
         self._repo = repo
 
+    @staticmethod
+    def _parse_remote_ref_names(ls_remote_output: str, prefix: str) -> set[str]:
+        r"""Parse ``git ls-remote`` output into a set of ref names.
+
+        Each line of *ls_remote_output* has the format ``<sha>\t<refname>``.
+        Only refs starting with *prefix* are included; the prefix is
+        stripped from each name.  Annotated-tag dereference entries
+        (ending with ``^{}``) are ignored.
+        """
+        ref_names: set[str] = set()
+        for line in ls_remote_output.splitlines():
+            if not line or "\t" not in line:
+                continue
+            _sha, raw_ref = line.split("\t", maxsplit=1)
+            if raw_ref.endswith("^{}"):
+                continue
+            if raw_ref.startswith(prefix):
+                ref_names.add(raw_ref.removeprefix(prefix))
+        return ref_names
+
     def get_latest_stable_tag(self) -> Version | None:
         """Return the highest stable semver tag, or ``None``.
 
-        Only tags matching ``vMAJOR.MINOR.PATCH`` (no pre-release
-        suffix) are considered.
+        Queries origin directly via ``ls-remote`` so behaviour is
+        consistent regardless of local fetch state.  Only tags matching
+        ``vMAJOR.MINOR.PATCH`` (no pre-release suffix) are considered.
         """
-        versions: list[Version] = []
+        ls_remote_output = self._repo.git.ls_remote("--tags", "origin")
+        remote_tag_names = self._parse_remote_ref_names(
+            ls_remote_output, prefix="refs/tags/"
+        )
 
-        for tag in self._repo.tags:
-            match = self._STABLE_TAG_PATTERN.match(tag.name)
+        versions: list[Version] = []
+        for tag_name in remote_tag_names:
+            match = self._STABLE_TAG_PATTERN.match(tag_name)
             if match:
                 versions.append(Version.parse(match.group(1)))
 
@@ -38,26 +63,97 @@ class GitHelper:
 
         A release is in-flight when a ``release/X.Y.Z`` branch exists
         on origin but the corresponding stable tag ``vX.Y.Z`` has not
-        been created yet.
+        been created yet.  Both checks query origin via ``ls-remote``.
         """
+        remote_tag_output = self._repo.git.ls_remote("--tags", "origin")
+        remote_tag_names = self._parse_remote_ref_names(
+            remote_tag_output, prefix="refs/tags/"
+        )
         stable_tags = {
-            tag.name
-            for tag in self._repo.tags
-            if self._STABLE_TAG_PATTERN.match(tag.name)
+            name for name in remote_tag_names
+            if self._STABLE_TAG_PATTERN.match(name)
         }
 
-        for ref in self._repo.remotes.origin.refs:
-            if not ref.name.startswith("origin/release/"):
+        remote_branch_output = self._repo.git.ls_remote("--heads", "origin")
+        remote_branch_names = self._parse_remote_ref_names(
+            remote_branch_output, prefix="refs/heads/"
+        )
+
+        for branch_name in remote_branch_names:
+            if not branch_name.startswith("release/"):
                 continue
-            version = ref.name.removeprefix("origin/release/")
+            version = branch_name.removeprefix("release/")
             if f"v{version}" not in stable_tags:
                 return version
 
         return None
 
-    def create_release_branch(self, version: str) -> None:
-        """Create a ``release/{version}`` branch and push it to origin."""
-        branch = self._repo.create_head(f"release/{version}")
+    def get_next_rc_number(self, version: str) -> int:
+        """Return the next RC number for the given version.
+
+        Queries origin via ``ls-remote`` to find existing RC tags
+        for *version* and returns the next sequential number.
+        Returns ``1`` if no RC tags exist yet.
+        """
+        ls_remote_output = self._repo.git.ls_remote("--tags", "origin")
+        remote_tag_names = self._parse_remote_ref_names(
+            ls_remote_output, prefix="refs/tags/"
+        )
+
+        rc_pattern = re.compile(rf"^v{re.escape(version)}-rc\.(\d+)$")
+        rc_numbers: list[int] = []
+        for tag_name in remote_tag_names:
+            match = rc_pattern.match(tag_name)
+            if match:
+                rc_numbers.append(int(match.group(1)))
+
+        if not rc_numbers:
+            return 1
+
+        return max(rc_numbers) + 1
+
+    def get_next_hotfix_version(self, base_version: Version) -> Version:
+        """Return the next available hotfix version for *base_version*.
+
+        Scans all remote tags in a single ``ls-remote`` call to find
+        the highest patch number in use for the same ``major.minor``
+        series (counting both stable tags and RC tags as "used"),
+        then returns the next patch version.
+        """
+        ls_remote_output = self._repo.git.ls_remote("--tags", "origin")
+        remote_tag_names = self._parse_remote_ref_names(
+            ls_remote_output, prefix="refs/tags/"
+        )
+
+        version_prefix = f"v{base_version.major}.{base_version.minor}."
+        patch_pattern = re.compile(
+            rf"^v{base_version.major}\.{base_version.minor}\.(\d+)(?:-rc\.\d+)?$"
+        )
+
+        highest_patch = base_version.patch
+        for tag_name in remote_tag_names:
+            if not tag_name.startswith(version_prefix):
+                continue
+            match = patch_pattern.match(tag_name)
+            if match:
+                patch = int(match.group(1))
+                highest_patch = max(highest_patch, patch)
+
+        return Version(base_version.major, base_version.minor, highest_patch + 1)
+
+    def create_release_branch(
+        self, version: str, source_ref: str | None = None
+    ) -> None:
+        """Create a ``release/{version}`` branch and push it to origin.
+
+        If *source_ref* is provided, the branch is created at that ref
+        instead of HEAD.  This is used for hotfixes that branch from a
+        stable tag.
+        """
+        if source_ref:
+            branch = self._repo.create_head(f"release/{version}", commit=source_ref)
+        else:
+            branch = self._repo.create_head(f"release/{version}")
         self._repo.remotes.origin.push(branch.name)
 
     def create_rc_tag(self, version: str, rc_number: int = 1) -> str:
@@ -83,3 +179,27 @@ class GitHelper:
     def get_head_sha(self) -> str:
         """Return the SHA of the current HEAD commit."""
         return self._repo.head.commit.hexsha
+
+    def configure_identity(self, name: str, email: str) -> None:
+        """Set the git user name and email for the repo."""
+        with self._repo.config_writer() as config:
+            config.set_value("user", "name", name)
+            config.set_value("user", "email", email)
+
+    def create_final_tag(self, tag_name: str, source_ref: str) -> bool:
+        """Create an annotated release tag at *source_ref* and push it.
+
+        Returns ``True`` if a new tag was created, ``False`` if it
+        already existed on origin.
+        """
+        ls_remote_output = self._repo.git.ls_remote("--tags", "origin")
+        remote_tag_names = self._parse_remote_ref_names(
+            ls_remote_output, prefix="refs/tags/"
+        )
+
+        if tag_name in remote_tag_names:
+            return False
+
+        self._repo.create_tag(tag_name, ref=source_ref, message=f"Release {tag_name}")
+        self._repo.remotes.origin.push(tag_name)
+        return True

--- a/src/release_tools/git.py
+++ b/src/release_tools/git.py
@@ -91,8 +91,7 @@ class GitHelper:
             remote_tag_output, prefix="refs/tags/"
         )
         stable_tags = {
-            name for name in remote_tag_names
-            if self._STABLE_TAG_PATTERN.match(name)
+            name for name in remote_tag_names if self._STABLE_TAG_PATTERN.match(name)
         }
 
         remote_branch_output = self._repo.git.ls_remote("--heads", "origin")

--- a/src/release_tools/git.py
+++ b/src/release_tools/git.py
@@ -35,6 +35,27 @@ class GitHelper:
                 ref_names.add(raw_ref.removeprefix(prefix))
         return ref_names
 
+    @staticmethod
+    def _resolve_remote_tag_sha(ls_remote_output: str, tag_name: str) -> str | None:
+        r"""Return the commit SHA for *tag_name* from ``ls-remote`` output.
+
+        For annotated tags, prefers the dereferenced ``^{}`` line
+        (the actual commit SHA).  For lightweight tags, returns the
+        only SHA present.  Returns ``None`` if the tag is not found.
+        """
+        tag_ref = f"refs/tags/{tag_name}"
+        deref_ref = f"{tag_ref}^{{}}"
+        tag_sha: str | None = None
+        for line in ls_remote_output.splitlines():
+            if not line or "\t" not in line:
+                continue
+            sha, raw_ref = line.split("\t", maxsplit=1)
+            if raw_ref == deref_ref:
+                return sha
+            if raw_ref == tag_ref:
+                tag_sha = sha
+        return tag_sha
+
     def get_latest_stable_tag(self) -> Version | None:
         """Return the highest stable semver tag, or ``None``.
 
@@ -146,12 +167,22 @@ class GitHelper:
     ) -> None:
         """Create a ``release/{version}`` branch and push it to origin.
 
-        If *source_ref* is provided, the branch is created at that ref
-        instead of HEAD.  This is used for hotfixes that branch from a
-        stable tag.
+        If *source_ref* is provided, it is resolved to a commit SHA
+        via ``ls-remote`` so it does not need to exist in the local
+        clone.  This is used for hotfixes that branch from a stable
+        tag.
+
+        Raises:
+            ValueError: If *source_ref* is not found on origin.
+
         """
         if source_ref:
-            branch = self._repo.create_head(f"release/{version}", commit=source_ref)
+            ls_remote_output = self._repo.git.ls_remote("--tags", "origin")
+            source_sha = self._resolve_remote_tag_sha(ls_remote_output, source_ref)
+            if not source_sha:
+                msg = f"Source tag {source_ref} not found on origin"
+                raise ValueError(msg)
+            branch = self._repo.create_head(f"release/{version}", commit=source_sha)
         else:
             branch = self._repo.create_head(f"release/{version}")
         self._repo.remotes.origin.push(branch.name)
@@ -189,8 +220,14 @@ class GitHelper:
     def create_final_tag(self, tag_name: str, source_ref: str) -> bool:
         """Create an annotated release tag at *source_ref* and push it.
 
-        Returns ``True`` if a new tag was created, ``False`` if it
-        already existed on origin.
+        Resolves *source_ref* to a commit SHA via ``ls-remote`` so the
+        tag does not need to exist in the local clone.  Returns ``True``
+        if a new tag was created, ``False`` if it already existed on
+        origin.
+
+        Raises:
+            ValueError: If *source_ref* is not found on origin.
+
         """
         ls_remote_output = self._repo.git.ls_remote("--tags", "origin")
         remote_tag_names = self._parse_remote_ref_names(
@@ -200,6 +237,11 @@ class GitHelper:
         if tag_name in remote_tag_names:
             return False
 
-        self._repo.create_tag(tag_name, ref=source_ref, message=f"Release {tag_name}")
+        source_sha = self._resolve_remote_tag_sha(ls_remote_output, source_ref)
+        if not source_sha:
+            msg = f"Source tag {source_ref} not found on origin"
+            raise ValueError(msg)
+
+        self._repo.create_tag(tag_name, ref=source_sha, message=f"Release {tag_name}")
         self._repo.remotes.origin.push(tag_name)
         return True

--- a/src/release_tools/github.py
+++ b/src/release_tools/github.py
@@ -1,5 +1,6 @@
 """GitHub API operations for the release pipeline."""
 
+from github import UnknownObjectException
 from github.GithubObject import NotSet
 from github.Repository import Repository
 
@@ -42,3 +43,160 @@ class GitHubHelper:
             ref=branch,
             inputs={"version": tag_name},
         )
+
+    def validate_tag_exists(self, tag_name: str) -> None:
+        """Raise if the given tag does not exist on GitHub.
+
+        Raises:
+            ValueError: If the tag is not found.
+
+        """
+        try:
+            self._repo.get_git_ref(f"tags/{tag_name}")
+        except UnknownObjectException:
+            msg = f"Tag {tag_name} does not exist"
+            raise ValueError(msg) from None
+
+    def validate_release_branch_exists(self, version: str) -> None:
+        """Raise if the release branch for the given version does not exist.
+
+        Raises:
+            ValueError: If ``release/{version}`` branch is not found.
+
+        """
+        branch_name = f"release/{version}"
+        try:
+            self._repo.get_branch(branch_name)
+        except UnknownObjectException:
+            msg = (
+                f"No release branch {branch_name} found."
+                " Tags must belong to a release branch."
+            )
+            raise ValueError(msg) from None
+
+    def validate_not_finalised(self, version: str) -> None:
+        """Raise if the given version already has a final release tag.
+
+        Raises:
+            ValueError: If the stable tag ``v{version}`` exists.
+
+        """
+        try:
+            self._repo.get_git_ref(f"tags/v{version}")
+        except UnknownObjectException:
+            return
+        msg = (
+            f"Release v{version} is already finalised."
+            " Use the Hotfix workflow to create a patch release instead."
+        )
+        raise ValueError(msg)
+
+    def validate_release_branch_does_not_exist(self, version: str) -> None:
+        """Raise if the release branch for the given version already exists.
+
+        Raises:
+            ValueError: If ``release/{version}`` branch is found.
+
+        """
+        branch_name = f"release/{version}"
+        try:
+            self._repo.get_branch(branch_name)
+        except UnknownObjectException:
+            return
+        msg = f"Branch {branch_name} already exists"
+        raise ValueError(msg)
+
+    def get_mergeback_count(self, branch: str) -> int:
+        """Count commits on *branch* that are not on ``main``.
+
+        Uses the GitHub compare API so no local history is needed.
+        """
+        comparison = self._repo.compare("main", branch)
+        return comparison.ahead_by
+
+    def find_previous_stable_release(self, exclude_tag: str) -> str | None:
+        """Find the previous stable release tag, excluding *exclude_tag*.
+
+        Returns the tag name of the most recent non-draft,
+        non-pre-release release, or ``None`` if there is none.
+        """
+        for release in self._repo.get_releases():
+            if release.draft or release.prerelease:
+                continue
+            if release.tag_name == exclude_tag:
+                continue
+            return release.tag_name
+        return None
+
+    def publish_stable_release(self, tag_name: str, previous_tag: str | None) -> None:
+        """Create the final stable GitHub Release for *tag_name*.
+
+        If a draft release already exists for the tag it is deleted
+        first. If a published release already exists the method
+        returns without making changes.
+        """
+        try:
+            existing = self._repo.get_release(tag_name)
+            if existing.draft:
+                existing.delete_release()
+            else:
+                return
+        except UnknownObjectException:
+            pass
+
+        notes = self._repo.generate_release_notes(
+            tag_name=tag_name,
+            previous_tag_name=previous_tag or NotSet,
+        )
+        self._repo.create_git_release(
+            tag=tag_name,
+            name=tag_name,
+            message=notes.body,
+            make_latest="true",
+        )
+
+    def annotate_release_with_mergeback(
+        self, tag_name: str, branch: str, ahead_count: int
+    ) -> None:
+        """Append a merge-back warning to the release body."""
+        release = self._repo.get_release(tag_name)
+        merge_note = (
+            "\n\n---\n\n"
+            "\u26a0\ufe0f **Merge-back required:** This release has"
+            f" {ahead_count} commit(s) on `{branch}` that are not on"
+            " `main`. See the merge-back issue for instructions."
+        )
+        release.update_release(
+            name=release.title,
+            message=release.body + merge_note,
+        )
+
+    def create_mergeback_issue(
+        self, tag_name: str, branch: str, ahead_count: int
+    ) -> str:
+        """Create a merge-back issue and return its URL."""
+        merge_version = tag_name.removeprefix("v")
+        repo_name = self._repo.full_name
+        body = (
+            f"Release **{tag_name}** has {ahead_count} commit(s) on"
+            f" `{branch}` that need merging back to `main`.\n\n"
+            "## Steps\n\n"
+            "```bash\n"
+            "git fetch origin\n"
+            "git checkout main\n"
+            "git pull origin main\n"
+            f"git checkout -b merge-back/{merge_version}\n"
+            f"git merge origin/{branch}\n"
+            "# Resolve conflicts if any\n"
+            f"git push origin merge-back/{merge_version}\n"
+            "```\n\n"
+            f"Then open a PR from `merge-back/{merge_version}` to `main`:\n\n"
+            f"https://github.com/{repo_name}"
+            f"/compare/main...merge-back/{merge_version}?expand=1\n\n"
+            "Close this issue once the PR is merged."
+        )
+        issue = self._repo.create_issue(
+            title=f"Merge back: {tag_name}",
+            body=body,
+        )
+        return issue.html_url

--- a/src/release_tools/hotfix.py
+++ b/src/release_tools/hotfix.py
@@ -1,0 +1,68 @@
+"""Hotfix command."""
+
+import os
+from pathlib import Path
+
+from release_tools.git import GitHelper
+from release_tools.github import GitHubHelper
+from release_tools.version import ReleaseVersionHelper
+
+
+class Hotfix:
+    """Command to create a hotfix release branch."""
+
+    def __init__(self, git: GitHelper, github: GitHubHelper, raw_version: str) -> None:
+        """Initialise with helpers and the base version string."""
+        self._git = git
+        self._github = github
+        self._base_version = ReleaseVersionHelper.parse(raw_version)
+
+    def run(self) -> None:
+        """Orchestrate creating a hotfix release branch."""
+        base_version_str = str(self._base_version)
+        base_tag = f"v{base_version_str}"
+
+        print(f"Hotfixing {base_tag}...")
+
+        self._github.validate_tag_exists(base_tag)
+
+        hotfix_version = self._git.get_next_hotfix_version(self._base_version)
+        hotfix_version_str = str(hotfix_version)
+        print(f"Hotfix version: {hotfix_version_str}")
+
+        self._github.validate_release_branch_does_not_exist(hotfix_version_str)
+
+        self._git.create_release_branch(hotfix_version_str, source_ref=base_tag)
+        print(f"Created branch release/{hotfix_version_str} from {base_tag}")
+
+        commit_sha = self._git.get_head_sha()
+        self._write_summary(base_version_str, hotfix_version_str, commit_sha)
+
+    @staticmethod
+    def _write_summary(
+        base_version: str, hotfix_version: str, commit_sha: str
+    ) -> None:
+        """Write the hotfix summary to step summary or stdout."""
+        summary = (
+            "## Hotfix Branch Created\n"
+            "\n"
+            f"- **Hotfixing:** v{base_version}\n"
+            f"- **Hotfix version:** {hotfix_version}\n"
+            f"- **Branch:** release/{hotfix_version}\n"
+            f"- **Branched from:** v{base_version} ({commit_sha})\n"
+            "\n"
+            "### Next steps\n"
+            f"1. Push your fix to `release/{hotfix_version}`"
+            " (directly or via PR)\n"
+            "2. Run **Tag New RC**"
+            f" (from branch `release/{hotfix_version}`)"
+            f" with version `{hotfix_version}` to start promotion\n"
+            "3. After prod deployment, the merge-back issue"
+            " will be created automatically\n"
+        )
+        summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+        if summary_path:
+            with Path(summary_path).open("a") as fh:
+                fh.write(summary)
+        else:
+            print(summary)

--- a/src/release_tools/hotfix.py
+++ b/src/release_tools/hotfix.py
@@ -39,9 +39,7 @@ class Hotfix:
         self._write_summary(base_version_str, hotfix_version_str, commit_sha)
 
     @staticmethod
-    def _write_summary(
-        base_version: str, hotfix_version: str, commit_sha: str
-    ) -> None:
+    def _write_summary(base_version: str, hotfix_version: str, commit_sha: str) -> None:
         """Write the hotfix summary to step summary or stdout."""
         summary = (
             "## Hotfix Branch Created\n"

--- a/src/release_tools/tag_rc.py
+++ b/src/release_tools/tag_rc.py
@@ -1,0 +1,71 @@
+"""Tag RC command."""
+
+import os
+from pathlib import Path
+
+from release_tools.git import GitHelper
+from release_tools.github import GitHubHelper
+from release_tools.version import ReleaseVersionHelper
+
+
+class TagRC:
+    """Command to tag a new release candidate."""
+
+    def __init__(self, git: GitHelper, github: GitHubHelper, raw_version: str) -> None:
+        """Initialise with helpers and the release version string."""
+        self._git = git
+        self._github = github
+        self._version = ReleaseVersionHelper.parse(raw_version)
+
+    def run(self) -> None:
+        """Orchestrate tagging a new release candidate."""
+        version_str = str(self._version)
+        branch = f"release/{version_str}"
+
+        self._github.validate_release_branch_exists(version_str)
+        self._github.validate_not_finalised(version_str)
+
+        rc_number = self._git.get_next_rc_number(version_str)
+        print(f"Next RC number: {rc_number}")
+
+        tag_name = self._git.create_rc_tag(version_str, rc_number=rc_number)
+        print(f"Created tag {tag_name}")
+
+        url = self._github.create_prerelease(tag_name, branch)
+        print(f"Pre-release published: {url}")
+
+        self._github.trigger_promotion(branch, tag_name)
+        print(f"Promotion pipeline triggered for {tag_name}")
+
+        commit_sha = self._git.get_head_sha()
+        self._write_summary(version_str, tag_name, commit_sha)
+
+    @staticmethod
+    def _write_summary(version: str, tag_name: str, commit_sha: str) -> None:
+        """Write the tag-rc summary to step summary or stdout."""
+        summary = (
+            "## New RC Tagged\n"
+            "\n"
+            f"- **Tag:** {tag_name}\n"
+            f"- **Pre-release:** {tag_name} (published)\n"
+            f"- **Branch:** release/{version}\n"
+            f"- **Commit:** {commit_sha}\n"
+            "\n"
+            "### Next steps\n"
+            "1. The **Promote** workflow has been triggered"
+            " automatically — check the Actions tab\n"
+            "2. Any previous promote run for this release"
+            " will be cancelled automatically\n"
+            "3. Test will deploy automatically."
+            " Approve **preprod** and **prod** when prompted\n"
+            f"4. If another problem is found, fix it on `release/{version}`"
+            " and run **Tag New RC** again\n"
+            "5. Check the **Releases** page"
+            " — the new pre-release is visible\n"
+        )
+        summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+        if summary_path:
+            with Path(summary_path).open("a") as fh:
+                fh.write(summary)
+        else:
+            print(summary)

--- a/src/release_tools/validate_promotion.py
+++ b/src/release_tools/validate_promotion.py
@@ -1,0 +1,55 @@
+"""Validate promotion command."""
+
+import os
+from pathlib import Path
+
+from release_tools.github import GitHubHelper
+from release_tools.version import ReleaseVersionHelper
+
+
+class ValidatePromotion:
+    """Command to validate an RC tag for promotion."""
+
+    def __init__(self, github: GitHubHelper, raw_version: str) -> None:
+        """Initialise with a GitHub helper and RC tag string."""
+        self._github = github
+        self._raw_version = raw_version
+
+    def run(self) -> str:
+        """Validate the RC tag and return the normalised tag name.
+
+        Checks that:
+        1. The version is a valid RC tag (e.g., v1.2.0-rc.1)
+        2. The tag exists on GitHub
+        3. The corresponding release branch exists
+
+        Returns the normalised tag name (e.g., ``v1.2.0-rc.1``).
+
+        Raises:
+            ValueError: If any validation check fails.
+
+        """
+        version = ReleaseVersionHelper.parse_rc(self._raw_version)
+
+        tag_name = f"v{version}"
+        print(f"Validating RC tag {tag_name}...")
+
+        self._github.validate_tag_exists(tag_name)
+        print(f"  Tag {tag_name} exists")
+
+        base_version = f"{version.major}.{version.minor}.{version.patch}"
+        self._github.validate_release_branch_exists(base_version)
+        print(f"  Release branch release/{base_version} exists")
+
+        self._write_output(tag_name)
+        return tag_name
+
+    @staticmethod
+    def _write_output(tag_name: str) -> None:
+        """Write the validated version to GITHUB_OUTPUT or stdout."""
+        output_path = os.environ.get("GITHUB_OUTPUT")
+        if output_path:
+            with Path(output_path).open("a") as fh:
+                fh.write(f"version={tag_name}\n")
+        else:
+            print(f"version={tag_name}")

--- a/src/release_tools/version.py
+++ b/src/release_tools/version.py
@@ -1,5 +1,7 @@
 """Version parsing and validation."""
 
+import re
+
 from semver import Version
 
 
@@ -49,3 +51,22 @@ class ReleaseVersionHelper:
                 f" than the latest release {latest_release}"
             )
             raise ValueError(msg)
+
+    @staticmethod
+    def parse_rc(raw_version: str) -> Version:
+        """Parse an RC tag string into a ``semver.Version``.
+
+        Strips an optional 'v' prefix and validates the pre-release
+        suffix matches ``rc.N``.
+
+        Raises:
+            ValueError: If the input is not a valid RC tag.
+
+        """
+        version = ReleaseVersionHelper.parse(raw_version)
+
+        if not version.prerelease or not re.match(r"^rc\.\d+$", version.prerelease):
+            msg = f"Version must be an RC tag (e.g., v1.2.0-rc.1), got: {raw_version}"
+            raise ValueError(msg)
+
+        return version

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -8,9 +8,13 @@ from github import Github
 from invoke import Context, Exit, task
 
 from release_tools.cut_release import CutRelease
+from release_tools.finalise_promotion import FinalisePromotion
 from release_tools.git import GitHelper
 from release_tools.github import GitHubHelper
 from release_tools.github_actions import GitHubActionsHelper
+from release_tools.hotfix import Hotfix
+from release_tools.tag_rc import TagRC
+from release_tools.validate_promotion import ValidatePromotion
 
 
 @task(help={"version": "Release version (e.g., 1.2.0 or v1.2.0)"})
@@ -39,5 +43,136 @@ def cut_release(_ctx: Context, version: str) -> None:
 
     try:
         CutRelease(git, github, version).run()
+    except (ValueError, RuntimeError) as err:
+        raise Exit(str(err), code=1) from err
+
+
+@task(help={"version": "RC tag to validate (e.g., v1.2.0-rc.1)"})
+def validate_promotion(_ctx: Context, version: str) -> None:
+    """Validate an RC tag for promotion.
+
+    Checks that the version is a valid RC tag, the tag exists on
+    GitHub, and the corresponding release branch exists.
+
+    On GitHub Actions, GH_TOKEN and GITHUB_REPOSITORY are provided
+    by the runner environment. When running locally, create a ``.env``
+    file in the project root with::
+
+        GH_TOKEN=<personal access token with repo scope>
+
+    The repository name is derived from the git origin remote.
+    """
+    if GitHubActionsHelper.is_running_in_actions():
+        token = os.environ["GH_TOKEN"]
+        repo_name = os.environ["GITHUB_REPOSITORY"]
+    else:
+        load_dotenv()
+        token = os.environ["GH_TOKEN"]
+        repo_name = GitHelper(Repo(".")).get_repo_name()
+
+    github = GitHubHelper(Github(token).get_repo(repo_name))
+
+    try:
+        ValidatePromotion(github, version).run()
+    except ValueError as err:
+        raise Exit(str(err), code=1) from err
+
+
+@task(help={"version": "RC tag to finalise (e.g., v1.2.0-rc.1)"})
+def finalise_promotion(_ctx: Context, version: str) -> None:
+    """Finalise a promoted RC into a stable release.
+
+    Creates the final tag, publishes the stable GitHub Release,
+    and handles merge-back detection.
+
+    On GitHub Actions, GH_TOKEN and GITHUB_REPOSITORY are provided
+    by the runner environment. When running locally, create a ``.env``
+    file in the project root with::
+
+        GH_TOKEN=<personal access token with repo scope>
+
+    The repository name is derived from the git origin remote.
+    """
+    git = GitHelper(Repo("."))
+
+    if GitHubActionsHelper.is_running_in_actions():
+        token = os.environ["GH_TOKEN"]
+        repo_name = os.environ["GITHUB_REPOSITORY"]
+    else:
+        load_dotenv()
+        token = os.environ["GH_TOKEN"]
+        repo_name = git.get_repo_name()
+
+    github = GitHubHelper(Github(token).get_repo(repo_name))
+
+    try:
+        FinalisePromotion(git, github, version).run()
+    except (ValueError, RuntimeError) as err:
+        raise Exit(str(err), code=1) from err
+
+
+@task(help={"version": "Release version (e.g., 1.2.0 or v1.2.0)"})
+def tag_rc(_ctx: Context, version: str) -> None:
+    """Tag a new release candidate on an existing release branch.
+
+    Auto-increments the RC number, creates the tag and pre-release,
+    and triggers the promotion pipeline.
+
+    On GitHub Actions, GH_TOKEN and GITHUB_REPOSITORY are provided
+    by the runner environment. When running locally, create a ``.env``
+    file in the project root with::
+
+        GH_TOKEN=<personal access token with repo scope>
+
+    The repository name is derived from the git origin remote.
+    """
+    git = GitHelper(Repo("."))
+
+    if GitHubActionsHelper.is_running_in_actions():
+        token = os.environ["GH_TOKEN"]
+        repo_name = os.environ["GITHUB_REPOSITORY"]
+    else:
+        load_dotenv()
+        token = os.environ["GH_TOKEN"]
+        repo_name = git.get_repo_name()
+
+    github = GitHubHelper(Github(token).get_repo(repo_name))
+
+    try:
+        TagRC(git, github, version).run()
+    except (ValueError, RuntimeError) as err:
+        raise Exit(str(err), code=1) from err
+
+
+@task(help={"base_version": "Release version to hotfix (e.g., 1.3.0 or v1.3.0)"})
+def hotfix(_ctx: Context, base_version: str) -> None:
+    """Create a hotfix release branch from a finalised release.
+
+    Determines the next available patch version, validates no
+    branch conflict, and creates the release branch from the
+    base release tag.
+
+    On GitHub Actions, GH_TOKEN and GITHUB_REPOSITORY are provided
+    by the runner environment. When running locally, create a ``.env``
+    file in the project root with::
+
+        GH_TOKEN=<personal access token with repo scope>
+
+    The repository name is derived from the git origin remote.
+    """
+    git = GitHelper(Repo("."))
+
+    if GitHubActionsHelper.is_running_in_actions():
+        token = os.environ["GH_TOKEN"]
+        repo_name = os.environ["GITHUB_REPOSITORY"]
+    else:
+        load_dotenv()
+        token = os.environ["GH_TOKEN"]
+        repo_name = git.get_repo_name()
+
+    github = GitHubHelper(Github(token).get_repo(repo_name))
+
+    try:
+        Hotfix(git, github, base_version).run()
     except (ValueError, RuntimeError) as err:
         raise Exit(str(err), code=1) from err

--- a/tests/unit/release_tools/test_finalise_promotion.py
+++ b/tests/unit/release_tools/test_finalise_promotion.py
@@ -1,0 +1,136 @@
+"""Unit tests for FinalisePromotion."""
+
+from unittest import mock
+
+import pytest
+from pytest_mock import MockerFixture
+from semver import Version
+
+from release_tools.finalise_promotion import FinalisePromotion
+from release_tools.git import GitHelper
+from release_tools.github import GitHubHelper
+
+
+class TestFinalisePromotion:
+    """Tests for FinalisePromotion."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, mocker: MockerFixture) -> None:
+        self.mock_git = mocker.Mock(spec_set=GitHelper)
+        self.mock_github = mocker.Mock(spec_set=GitHubHelper)
+        self.mock_git.create_final_tag.return_value = True
+        self.mock_github.get_mergeback_count.return_value = 0
+        self.mock_github.find_previous_stable_release.return_value = "v1.0.0"
+        self.mock_github.create_mergeback_issue.return_value = (
+            "https://github.com/owner/repo/issues/1"
+        )
+        mocker.patch(
+            "release_tools.finalise_promotion.ReleaseVersionHelper.parse_rc",
+            return_value=Version.parse("2.0.0-rc.1"),
+        )
+
+    def test_run_configures_git_identity(self) -> None:
+        FinalisePromotion(self.mock_git, self.mock_github, "v2.0.0-rc.1").run()
+
+        self.mock_git.configure_identity.assert_called_once_with(
+            "github-actions[bot]",
+            "github-actions[bot]@users.noreply.github.com",
+        )
+
+    def test_run_creates_final_tag_from_rc(self) -> None:
+        FinalisePromotion(self.mock_git, self.mock_github, "v2.0.0-rc.1").run()
+
+        self.mock_git.create_final_tag.assert_called_once_with("v2.0.0", "v2.0.0-rc.1")
+
+    def test_run_finds_previous_stable_release(self) -> None:
+        FinalisePromotion(self.mock_git, self.mock_github, "v2.0.0-rc.1").run()
+
+        self.mock_github.find_previous_stable_release.assert_called_once_with("v2.0.0")
+
+    def test_run_publishes_stable_release_with_previous_tag(self) -> None:
+        FinalisePromotion(self.mock_git, self.mock_github, "v2.0.0-rc.1").run()
+
+        self.mock_github.publish_stable_release.assert_called_once_with(
+            "v2.0.0", "v1.0.0"
+        )
+
+    def test_run_publishes_stable_release_with_none_when_first(
+        self,
+    ) -> None:
+        self.mock_github.find_previous_stable_release.return_value = None
+
+        FinalisePromotion(self.mock_git, self.mock_github, "v2.0.0-rc.1").run()
+
+        self.mock_github.publish_stable_release.assert_called_once_with("v2.0.0", None)
+
+    def test_run_checks_mergeback_count(self) -> None:
+        FinalisePromotion(self.mock_git, self.mock_github, "v2.0.0-rc.1").run()
+
+        self.mock_github.get_mergeback_count.assert_called_once_with("release/2.0.0")
+
+    def test_run_creates_mergeback_issue_when_ahead(self) -> None:
+        self.mock_github.get_mergeback_count.return_value = 3
+
+        FinalisePromotion(self.mock_git, self.mock_github, "v2.0.0-rc.1").run()
+
+        self.mock_github.annotate_release_with_mergeback.assert_called_once_with(
+            "v2.0.0", "release/2.0.0", 3
+        )
+        self.mock_github.create_mergeback_issue.assert_called_once_with(
+            "v2.0.0", "release/2.0.0", 3
+        )
+
+    def test_run_skips_mergeback_when_not_ahead(self) -> None:
+        self.mock_github.get_mergeback_count.return_value = 0
+
+        FinalisePromotion(self.mock_git, self.mock_github, "v2.0.0-rc.1").run()
+
+        self.mock_github.annotate_release_with_mergeback.assert_not_called()
+        self.mock_github.create_mergeback_issue.assert_not_called()
+
+    def test_run_calls_steps_in_correct_order(self) -> None:
+        self.mock_github.get_mergeback_count.return_value = 2
+
+        FinalisePromotion(self.mock_git, self.mock_github, "v2.0.0-rc.1").run()
+
+        git_methods = [call[0] for call in self.mock_git.method_calls]
+        github_methods = [call[0] for call in self.mock_github.method_calls]
+
+        assert git_methods.index("configure_identity") < git_methods.index(
+            "create_final_tag"
+        )
+        assert github_methods.index(
+            "find_previous_stable_release"
+        ) < github_methods.index("publish_stable_release")
+        assert github_methods.index("publish_stable_release") < github_methods.index(
+            "get_mergeback_count"
+        )
+        assert github_methods.index("get_mergeback_count") < github_methods.index(
+            "annotate_release_with_mergeback"
+        )
+
+    @mock.patch.dict("os.environ", {}, clear=True)
+    def test_run_writes_summary_without_mergeback(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        self.mock_github.get_mergeback_count.return_value = 0
+
+        FinalisePromotion(self.mock_git, self.mock_github, "v2.0.0-rc.1").run()
+
+        captured = capsys.readouterr()
+        assert "## Release Finalised" in captured.out
+        assert "v2.0.0" in captured.out
+        assert "v2.0.0-rc.1" in captured.out
+        assert "Merge-back required" not in captured.out
+
+    @mock.patch.dict("os.environ", {}, clear=True)
+    def test_run_writes_summary_with_mergeback(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        self.mock_github.get_mergeback_count.return_value = 3
+
+        FinalisePromotion(self.mock_git, self.mock_github, "v2.0.0-rc.1").run()
+
+        captured = capsys.readouterr()
+        assert "Merge-back required" in captured.out
+        assert "3 commit(s)" in captured.out

--- a/tests/unit/release_tools/test_git.py
+++ b/tests/unit/release_tools/test_git.py
@@ -218,13 +218,22 @@ class TestGitHelper:
     def test_create_release_branch_with_source_ref(self) -> None:
         mock_branch = self.mock_repo.create_head.return_value
         mock_branch.name = "release/1.3.1"
+        self.mock_repo.git.ls_remote.return_value = self._fake_ls_remote(
+            "refs/tags/v1.3.0",
+        )
 
         self.helper.create_release_branch("1.3.1", source_ref="v1.3.0")
 
         self.mock_repo.create_head.assert_called_once_with(
-            "release/1.3.1", commit="v1.3.0"
+            "release/1.3.1", commit="0" * 40
         )
         self.mock_origin.push.assert_called_once_with("release/1.3.1")
+
+    def test_create_release_branch_raises_when_source_ref_not_found(self) -> None:
+        self.mock_repo.git.ls_remote.return_value = ""
+
+        with pytest.raises(ValueError, match="not found on origin"):
+            self.helper.create_release_branch("1.3.1", source_ref="v1.3.0")
 
     def test_create_rc_tag_creates_and_pushes_tag(self) -> None:
         self.helper.create_rc_tag("1.2.0")
@@ -277,25 +286,46 @@ class TestGitHelper:
         mock_config.set_value.assert_any_call("user", "email", "bot@example.com")
 
     def test_create_final_tag_creates_and_pushes_when_new(self) -> None:
-        self.mock_repo.git.ls_remote.return_value = ""
+        self.mock_repo.git.ls_remote.return_value = self._fake_ls_remote(
+            "refs/tags/v1.2.0-rc.1",
+        )
 
         result = self.helper.create_final_tag("v1.2.0", "v1.2.0-rc.1")
 
         assert result is True
         self.mock_repo.create_tag.assert_called_once_with(
-            "v1.2.0", ref="v1.2.0-rc.1", message="Release v1.2.0"
+            "v1.2.0", ref="0" * 40, message="Release v1.2.0"
         )
         self.mock_origin.push.assert_called_once_with("v1.2.0")
 
     def test_create_final_tag_returns_false_when_tag_exists(self) -> None:
         self.mock_repo.git.ls_remote.return_value = self._fake_ls_remote(
             "refs/tags/v1.2.0",
+            "refs/tags/v1.2.0-rc.1",
         )
 
         result = self.helper.create_final_tag("v1.2.0", "v1.2.0-rc.1")
 
         assert result is False
         self.mock_repo.create_tag.assert_not_called()
+
+    def test_create_final_tag_raises_when_source_ref_not_found(self) -> None:
+        self.mock_repo.git.ls_remote.return_value = ""
+
+        with pytest.raises(ValueError, match="not found on origin"):
+            self.helper.create_final_tag("v1.2.0", "v1.2.0-rc.1")
+
+    def test_create_final_tag_prefers_dereferenced_sha(self) -> None:
+        self.mock_repo.git.ls_remote.return_value = (
+            "aaa111\trefs/tags/v1.2.0-rc.1\n"
+            "bbb222\trefs/tags/v1.2.0-rc.1^{}"
+        )
+
+        self.helper.create_final_tag("v1.2.0", "v1.2.0-rc.1")
+
+        self.mock_repo.create_tag.assert_called_once_with(
+            "v1.2.0", ref="bbb222", message="Release v1.2.0"
+        )
 
     @staticmethod
     def _fake_ls_remote(*ref_paths: str) -> str:

--- a/tests/unit/release_tools/test_git.py
+++ b/tests/unit/release_tools/test_git.py
@@ -21,26 +21,39 @@ class TestGitHelper:
     def test_get_latest_stable_tag_returns_highest_when_multiple_tags(
         self,
     ) -> None:
-        tag_1 = self._make_tag("v1.0.0")
-        tag_2 = self._make_tag("v2.0.0")
-        tag_3 = self._make_tag("v1.5.0")
-        self.mock_repo.tags = [tag_1, tag_2, tag_3]
+        self.mock_repo.git.ls_remote.return_value = self._fake_ls_remote(
+            "refs/tags/v1.0.0",
+            "refs/tags/v2.0.0",
+            "refs/tags/v1.5.0",
+        )
 
         result = self.helper.get_latest_stable_tag()
 
         assert result == Version.parse("2.0.0")
+        self.mock_repo.git.ls_remote.assert_called_once_with("--tags", "origin")
 
     def test_get_latest_stable_tag_returns_none_when_no_tags(self) -> None:
-        self.mock_repo.tags = []
+        self.mock_repo.git.ls_remote.return_value = ""
 
         result = self.helper.get_latest_stable_tag()
 
         assert result is None
 
     def test_get_latest_stable_tag_ignores_prerelease_tags(self) -> None:
-        tag_stable = self._make_tag("v1.0.0")
-        tag_rc = self._make_tag("v2.0.0-rc.1")
-        self.mock_repo.tags = [tag_stable, tag_rc]
+        self.mock_repo.git.ls_remote.return_value = self._fake_ls_remote(
+            "refs/tags/v1.0.0",
+            "refs/tags/v2.0.0-rc.1",
+        )
+
+        result = self.helper.get_latest_stable_tag()
+
+        assert result == Version.parse("1.0.0")
+
+    def test_get_latest_stable_tag_ignores_dereference_entries(self) -> None:
+        self.mock_repo.git.ls_remote.return_value = (
+            self._fake_ls_remote("refs/tags/v1.0.0")
+            + "\nabc123\trefs/tags/v1.0.0^{}"
+        )
 
         result = self.helper.get_latest_stable_tag()
 
@@ -49,9 +62,9 @@ class TestGitHelper:
     def test_get_inflight_release_returns_version_when_no_stable_tag(
         self,
     ) -> None:
-        self.mock_repo.tags = [self._make_tag("v1.0.0")]
-        self.mock_origin.refs = [
-            self._make_ref("origin/release/2.0.0"),
+        self.mock_repo.git.ls_remote.side_effect = [
+            self._fake_ls_remote("refs/tags/v1.0.0"),
+            self._fake_ls_remote("refs/heads/release/2.0.0"),
         ]
 
         result = self.helper.get_inflight_release()
@@ -61,9 +74,9 @@ class TestGitHelper:
     def test_get_inflight_release_returns_none_when_all_finalised(
         self,
     ) -> None:
-        self.mock_repo.tags = [self._make_tag("v1.0.0")]
-        self.mock_origin.refs = [
-            self._make_ref("origin/release/1.0.0"),
+        self.mock_repo.git.ls_remote.side_effect = [
+            self._fake_ls_remote("refs/tags/v1.0.0"),
+            self._fake_ls_remote("refs/heads/release/1.0.0"),
         ]
 
         result = self.helper.get_inflight_release()
@@ -73,12 +86,125 @@ class TestGitHelper:
     def test_get_inflight_release_returns_none_when_no_release_branches(
         self,
     ) -> None:
-        self.mock_repo.tags = []
-        self.mock_origin.refs = [self._make_ref("origin/main")]
+        self.mock_repo.git.ls_remote.side_effect = [
+            "",
+            self._fake_ls_remote("refs/heads/main"),
+        ]
 
         result = self.helper.get_inflight_release()
 
         assert result is None
+
+    def test_get_next_rc_number_returns_1_when_no_rc_tags(self) -> None:
+        self.mock_repo.git.ls_remote.return_value = ""
+
+        result = self.helper.get_next_rc_number("1.0.0")
+
+        assert result == 1
+
+    def test_get_next_rc_number_returns_next_after_highest(self) -> None:
+        self.mock_repo.git.ls_remote.return_value = self._fake_ls_remote(
+            "refs/tags/v1.0.0-rc.1",
+            "refs/tags/v1.0.0-rc.2",
+            "refs/tags/v1.0.0-rc.3",
+        )
+
+        result = self.helper.get_next_rc_number("1.0.0")
+
+        assert result == 4
+
+    def test_get_next_rc_number_ignores_other_version_rc_tags(self) -> None:
+        self.mock_repo.git.ls_remote.return_value = self._fake_ls_remote(
+            "refs/tags/v2.0.0-rc.5",
+        )
+
+        result = self.helper.get_next_rc_number("1.0.0")
+
+        assert result == 1
+
+    def test_get_next_rc_number_ignores_stable_tags(self) -> None:
+        self.mock_repo.git.ls_remote.return_value = self._fake_ls_remote(
+            "refs/tags/v1.0.0",
+            "refs/tags/v1.0.0-rc.2",
+        )
+
+        result = self.helper.get_next_rc_number("1.0.0")
+
+        assert result == 3
+
+    def test_get_next_rc_number_handles_non_sequential(self) -> None:
+        self.mock_repo.git.ls_remote.return_value = self._fake_ls_remote(
+            "refs/tags/v1.0.0-rc.1",
+            "refs/tags/v1.0.0-rc.5",
+        )
+
+        result = self.helper.get_next_rc_number("1.0.0")
+
+        assert result == 6
+
+    def test_get_next_hotfix_version_returns_patch_plus_1_when_no_higher(
+        self,
+    ) -> None:
+        self.mock_repo.git.ls_remote.return_value = self._fake_ls_remote(
+            "refs/tags/v1.3.0",
+        )
+
+        result = self.helper.get_next_hotfix_version(Version.parse("1.3.0"))
+
+        assert result == Version(1, 3, 1)
+
+    def test_get_next_hotfix_version_skips_existing_stable_patches(self) -> None:
+        self.mock_repo.git.ls_remote.return_value = self._fake_ls_remote(
+            "refs/tags/v1.3.0",
+            "refs/tags/v1.3.1",
+        )
+
+        result = self.helper.get_next_hotfix_version(Version.parse("1.3.0"))
+
+        assert result == Version(1, 3, 2)
+
+    def test_get_next_hotfix_version_skips_existing_rc_patches(self) -> None:
+        self.mock_repo.git.ls_remote.return_value = self._fake_ls_remote(
+            "refs/tags/v1.3.0",
+            "refs/tags/v1.3.1-rc.1",
+        )
+
+        result = self.helper.get_next_hotfix_version(Version.parse("1.3.0"))
+
+        assert result == Version(1, 3, 2)
+
+    def test_get_next_hotfix_version_finds_highest_across_stable_and_rc(
+        self,
+    ) -> None:
+        self.mock_repo.git.ls_remote.return_value = self._fake_ls_remote(
+            "refs/tags/v1.3.0",
+            "refs/tags/v1.3.1",
+            "refs/tags/v1.3.2-rc.1",
+        )
+
+        result = self.helper.get_next_hotfix_version(Version.parse("1.3.0"))
+
+        assert result == Version(1, 3, 3)
+
+    def test_get_next_hotfix_version_ignores_other_minor_versions(self) -> None:
+        self.mock_repo.git.ls_remote.return_value = self._fake_ls_remote(
+            "refs/tags/v1.3.0",
+            "refs/tags/v1.4.1",
+        )
+
+        result = self.helper.get_next_hotfix_version(Version.parse("1.3.0"))
+
+        assert result == Version(1, 3, 1)
+
+    def test_get_next_hotfix_version_ignores_other_major_versions(self) -> None:
+        self.mock_repo.git.ls_remote.return_value = self._fake_ls_remote(
+            "refs/tags/v1.3.0",
+            "refs/tags/v2.3.1",
+        )
+
+        result = self.helper.get_next_hotfix_version(Version.parse("1.3.0"))
+
+        assert result == Version(1, 3, 1)
 
     def test_create_release_branch_creates_and_pushes_branch(self) -> None:
         mock_branch = self.mock_repo.create_head.return_value
@@ -88,6 +214,17 @@ class TestGitHelper:
 
         self.mock_repo.create_head.assert_called_once_with("release/1.2.0")
         self.mock_origin.push.assert_called_once_with("release/1.2.0")
+
+    def test_create_release_branch_with_source_ref(self) -> None:
+        mock_branch = self.mock_repo.create_head.return_value
+        mock_branch.name = "release/1.3.1"
+
+        self.helper.create_release_branch("1.3.1", source_ref="v1.3.0")
+
+        self.mock_repo.create_head.assert_called_once_with(
+            "release/1.3.1", commit="v1.3.0"
+        )
+        self.mock_origin.push.assert_called_once_with("release/1.3.1")
 
     def test_create_rc_tag_creates_and_pushes_tag(self) -> None:
         self.helper.create_rc_tag("1.2.0")
@@ -127,10 +264,41 @@ class TestGitHelper:
 
         assert result == "abc123def456"
 
-    @staticmethod
-    def _make_tag(name: str) -> git.TagReference:
-        return type("Tag", (), {"name": name})()  # type: ignore[return-value]
+    def test_configure_identity_sets_user_name_and_email(
+        self, mocker: MockerFixture
+    ) -> None:
+        mock_writer = mocker.MagicMock()
+        self.mock_repo.config_writer.return_value = mock_writer
+        mock_config = mock_writer.__enter__.return_value
+
+        self.helper.configure_identity("Bot", "bot@example.com")
+
+        mock_config.set_value.assert_any_call("user", "name", "Bot")
+        mock_config.set_value.assert_any_call("user", "email", "bot@example.com")
+
+    def test_create_final_tag_creates_and_pushes_when_new(self) -> None:
+        self.mock_repo.git.ls_remote.return_value = ""
+
+        result = self.helper.create_final_tag("v1.2.0", "v1.2.0-rc.1")
+
+        assert result is True
+        self.mock_repo.create_tag.assert_called_once_with(
+            "v1.2.0", ref="v1.2.0-rc.1", message="Release v1.2.0"
+        )
+        self.mock_origin.push.assert_called_once_with("v1.2.0")
+
+    def test_create_final_tag_returns_false_when_tag_exists(self) -> None:
+        self.mock_repo.git.ls_remote.return_value = self._fake_ls_remote(
+            "refs/tags/v1.2.0",
+        )
+
+        result = self.helper.create_final_tag("v1.2.0", "v1.2.0-rc.1")
+
+        assert result is False
+        self.mock_repo.create_tag.assert_not_called()
 
     @staticmethod
-    def _make_ref(name: str) -> git.RemoteReference:
-        return type("Ref", (), {"name": name})()  # type: ignore[return-value]
+    def _fake_ls_remote(*ref_paths: str) -> str:
+        """Build fake ``git ls-remote`` output for the given ref paths."""
+        dummy_sha = "0" * 40
+        return "\n".join(f"{dummy_sha}\t{ref_path}" for ref_path in ref_paths)

--- a/tests/unit/release_tools/test_git.py
+++ b/tests/unit/release_tools/test_git.py
@@ -51,8 +51,7 @@ class TestGitHelper:
 
     def test_get_latest_stable_tag_ignores_dereference_entries(self) -> None:
         self.mock_repo.git.ls_remote.return_value = (
-            self._fake_ls_remote("refs/tags/v1.0.0")
-            + "\nabc123\trefs/tags/v1.0.0^{}"
+            self._fake_ls_remote("refs/tags/v1.0.0") + "\nabc123\trefs/tags/v1.0.0^{}"
         )
 
         result = self.helper.get_latest_stable_tag()
@@ -317,8 +316,7 @@ class TestGitHelper:
 
     def test_create_final_tag_prefers_dereferenced_sha(self) -> None:
         self.mock_repo.git.ls_remote.return_value = (
-            "aaa111\trefs/tags/v1.2.0-rc.1\n"
-            "bbb222\trefs/tags/v1.2.0-rc.1^{}"
+            "aaa111\trefs/tags/v1.2.0-rc.1\nbbb222\trefs/tags/v1.2.0-rc.1^{}"
         )
 
         self.helper.create_final_tag("v1.2.0", "v1.2.0-rc.1")

--- a/tests/unit/release_tools/test_github.py
+++ b/tests/unit/release_tools/test_github.py
@@ -1,6 +1,7 @@
 """Unit tests for GitHubHelper."""
 
 import pytest
+from github import UnknownObjectException
 from github.GithubObject import NotSet
 from github.Repository import Repository
 from pytest_mock import MockerFixture
@@ -78,3 +79,244 @@ class TestGitHubHelper:
             ref="release/1.0.0",
             inputs={"version": "v1.0.0-rc.1"},
         )
+
+    def test_validate_tag_exists_passes_when_tag_found(self) -> None:
+        self.helper.validate_tag_exists("v1.0.0-rc.1")
+
+        self.mock_repo.get_git_ref.assert_called_once_with("tags/v1.0.0-rc.1")
+
+    def test_validate_tag_exists_raises_when_tag_not_found(self) -> None:
+        self.mock_repo.get_git_ref.side_effect = UnknownObjectException(404, {}, {})
+
+        with pytest.raises(ValueError, match="does not exist"):
+            self.helper.validate_tag_exists("v1.0.0-rc.1")
+
+    def test_validate_release_branch_exists_passes_when_branch_found(
+        self,
+    ) -> None:
+        self.helper.validate_release_branch_exists("1.0.0")
+
+        self.mock_repo.get_branch.assert_called_once_with("release/1.0.0")
+
+    def test_validate_release_branch_exists_raises_when_branch_not_found(
+        self,
+    ) -> None:
+        self.mock_repo.get_branch.side_effect = UnknownObjectException(404, {}, {})
+
+        with pytest.raises(ValueError, match="No release branch"):
+            self.helper.validate_release_branch_exists("1.0.0")
+
+    # -- validate_not_finalised --
+
+    def test_validate_not_finalised_passes_when_tag_absent(self) -> None:
+        self.mock_repo.get_git_ref.side_effect = UnknownObjectException(404, {}, {})
+
+        self.helper.validate_not_finalised("1.0.0")
+
+        self.mock_repo.get_git_ref.assert_called_once_with("tags/v1.0.0")
+
+    def test_validate_not_finalised_raises_when_tag_exists(self) -> None:
+        with pytest.raises(ValueError, match="already finalised"):
+            self.helper.validate_not_finalised("1.0.0")
+
+    # -- validate_release_branch_does_not_exist --
+
+    def test_validate_release_branch_does_not_exist_passes_when_absent(
+        self,
+    ) -> None:
+        self.mock_repo.get_branch.side_effect = UnknownObjectException(404, {}, {})
+
+        self.helper.validate_release_branch_does_not_exist("1.0.0")
+
+        self.mock_repo.get_branch.assert_called_once_with("release/1.0.0")
+
+    def test_validate_release_branch_does_not_exist_raises_when_exists(
+        self,
+    ) -> None:
+        with pytest.raises(ValueError, match="already exists"):
+            self.helper.validate_release_branch_does_not_exist("1.0.0")
+
+    # -- get_mergeback_count --
+
+    def test_get_mergeback_count_returns_ahead_by(self, mocker: MockerFixture) -> None:
+        mock_comparison = mocker.Mock(ahead_by=3)
+        self.mock_repo.compare.return_value = mock_comparison
+
+        result = self.helper.get_mergeback_count("release/1.2.0")
+
+        assert result == 3
+        self.mock_repo.compare.assert_called_once_with("main", "release/1.2.0")
+
+    def test_get_mergeback_count_returns_zero_when_no_diff(
+        self, mocker: MockerFixture
+    ) -> None:
+        mock_comparison = mocker.Mock(ahead_by=0)
+        self.mock_repo.compare.return_value = mock_comparison
+
+        result = self.helper.get_mergeback_count("release/1.2.0")
+
+        assert result == 0
+
+    # -- find_previous_stable_release --
+
+    def test_find_previous_stable_release_returns_first_stable_tag(
+        self, mocker: MockerFixture
+    ) -> None:
+        releases = [
+            mocker.Mock(draft=False, prerelease=False, tag_name="v1.0.0"),
+        ]
+        self.mock_repo.get_releases.return_value = releases
+
+        result = self.helper.find_previous_stable_release("v2.0.0")
+
+        assert result == "v1.0.0"
+
+    def test_find_previous_stable_release_skips_drafts_and_prereleases(
+        self, mocker: MockerFixture
+    ) -> None:
+        releases = [
+            mocker.Mock(draft=True, prerelease=False, tag_name="v3.0.0"),
+            mocker.Mock(draft=False, prerelease=True, tag_name="v2.0.0-rc.1"),
+            mocker.Mock(draft=False, prerelease=False, tag_name="v1.0.0"),
+        ]
+        self.mock_repo.get_releases.return_value = releases
+
+        result = self.helper.find_previous_stable_release("v2.0.0")
+
+        assert result == "v1.0.0"
+
+    def test_find_previous_stable_release_skips_excluded_tag(
+        self, mocker: MockerFixture
+    ) -> None:
+        releases = [
+            mocker.Mock(draft=False, prerelease=False, tag_name="v2.0.0"),
+            mocker.Mock(draft=False, prerelease=False, tag_name="v1.0.0"),
+        ]
+        self.mock_repo.get_releases.return_value = releases
+
+        result = self.helper.find_previous_stable_release("v2.0.0")
+
+        assert result == "v1.0.0"
+
+    def test_find_previous_stable_release_returns_none_when_empty(
+        self,
+    ) -> None:
+        self.mock_repo.get_releases.return_value = []
+
+        result = self.helper.find_previous_stable_release("v1.0.0")
+
+        assert result is None
+
+    # -- publish_stable_release --
+
+    def test_publish_stable_release_creates_release_when_none_exists(
+        self,
+    ) -> None:
+        self.mock_repo.get_release.side_effect = UnknownObjectException(404, {}, {})
+        self.mock_repo.generate_release_notes.return_value.body = "notes"
+
+        self.helper.publish_stable_release("v1.0.0", "v0.9.0")
+
+        self.mock_repo.create_git_release.assert_called_once_with(
+            tag="v1.0.0",
+            name="v1.0.0",
+            message="notes",
+            make_latest="true",
+        )
+
+    def test_publish_stable_release_deletes_draft_then_creates(
+        self, mocker: MockerFixture
+    ) -> None:
+        mock_existing = mocker.Mock(draft=True)
+        self.mock_repo.get_release.return_value = mock_existing
+        self.mock_repo.generate_release_notes.return_value.body = "notes"
+
+        self.helper.publish_stable_release("v1.0.0", None)
+
+        mock_existing.delete_release.assert_called_once()
+        self.mock_repo.create_git_release.assert_called_once()
+
+    def test_publish_stable_release_skips_when_published_exists(
+        self, mocker: MockerFixture
+    ) -> None:
+        mock_existing = mocker.Mock(draft=False)
+        self.mock_repo.get_release.return_value = mock_existing
+
+        self.helper.publish_stable_release("v1.0.0", None)
+
+        self.mock_repo.create_git_release.assert_not_called()
+
+    def test_publish_stable_release_passes_previous_tag(self) -> None:
+        self.mock_repo.get_release.side_effect = UnknownObjectException(404, {}, {})
+        self.mock_repo.generate_release_notes.return_value.body = "notes"
+
+        self.helper.publish_stable_release("v1.0.0", "v0.9.0")
+
+        call_kwargs = self.mock_repo.generate_release_notes.call_args.kwargs
+        assert call_kwargs["previous_tag_name"] == "v0.9.0"
+
+    def test_publish_stable_release_uses_notset_when_no_previous(
+        self,
+    ) -> None:
+        self.mock_repo.get_release.side_effect = UnknownObjectException(404, {}, {})
+        self.mock_repo.generate_release_notes.return_value.body = "notes"
+
+        self.helper.publish_stable_release("v1.0.0", None)
+
+        call_kwargs = self.mock_repo.generate_release_notes.call_args.kwargs
+        assert call_kwargs["previous_tag_name"] is NotSet
+
+    # -- annotate_release_with_mergeback --
+
+    def test_annotate_release_with_mergeback_appends_note(
+        self, mocker: MockerFixture
+    ) -> None:
+        mock_release = mocker.Mock(title="v1.0.0", body="Existing notes")
+        self.mock_repo.get_release.return_value = mock_release
+
+        self.helper.annotate_release_with_mergeback("v1.0.0", "release/1.0.0", 3)
+
+        mock_release.update_release.assert_called_once()
+        call_kwargs = mock_release.update_release.call_args.kwargs
+        assert "Existing notes" in call_kwargs["message"]
+        assert "Merge-back required" in call_kwargs["message"]
+        assert "3 commit(s)" in call_kwargs["message"]
+
+    # -- create_mergeback_issue --
+
+    def test_create_mergeback_issue_creates_issue_with_correct_title(
+        self,
+    ) -> None:
+        self.mock_repo.full_name = "owner/repo"
+        self.mock_repo.create_issue.return_value.html_url = (
+            "https://github.com/owner/repo/issues/1"
+        )
+
+        self.helper.create_mergeback_issue("v1.0.0", "release/1.0.0", 3)
+
+        call_kwargs = self.mock_repo.create_issue.call_args.kwargs
+        assert call_kwargs["title"] == "Merge back: v1.0.0"
+
+    def test_create_mergeback_issue_body_contains_instructions(
+        self,
+    ) -> None:
+        self.mock_repo.full_name = "owner/repo"
+        self.mock_repo.create_issue.return_value.html_url = (
+            "https://github.com/owner/repo/issues/1"
+        )
+
+        self.helper.create_mergeback_issue("v1.0.0", "release/1.0.0", 3)
+
+        call_kwargs = self.mock_repo.create_issue.call_args.kwargs
+        assert "merge-back/1.0.0" in call_kwargs["body"]
+        assert "owner/repo" in call_kwargs["body"]
+
+    def test_create_mergeback_issue_returns_issue_url(self) -> None:
+        self.mock_repo.full_name = "owner/repo"
+        self.mock_repo.create_issue.return_value.html_url = (
+            "https://github.com/owner/repo/issues/1"
+        )
+
+        result = self.helper.create_mergeback_issue("v1.0.0", "release/1.0.0", 3)
+
+        assert result == "https://github.com/owner/repo/issues/1"

--- a/tests/unit/release_tools/test_hotfix.py
+++ b/tests/unit/release_tools/test_hotfix.py
@@ -1,0 +1,89 @@
+"""Unit tests for Hotfix."""
+
+from unittest import mock
+
+import pytest
+from pytest_mock import MockerFixture
+from semver import Version
+
+from release_tools.git import GitHelper
+from release_tools.github import GitHubHelper
+from release_tools.hotfix import Hotfix
+
+
+class TestHotfix:
+    """Tests for Hotfix."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, mocker: MockerFixture) -> None:
+        self.mock_git = mocker.Mock(spec_set=GitHelper)
+        self.mock_github = mocker.Mock(spec_set=GitHubHelper)
+        self.mock_git.get_next_hotfix_version.return_value = Version.parse("1.3.1")
+        self.mock_git.get_head_sha.return_value = "abc123"
+        mocker.patch(
+            "release_tools.hotfix.ReleaseVersionHelper.parse",
+            return_value=Version.parse("1.3.0"),
+        )
+
+    def test_run_validates_base_tag_exists(self) -> None:
+        Hotfix(self.mock_git, self.mock_github, "1.3.0").run()
+
+        self.mock_github.validate_tag_exists.assert_called_once_with("v1.3.0")
+
+    def test_run_raises_when_base_tag_not_found(self) -> None:
+        self.mock_github.validate_tag_exists.side_effect = ValueError("not found")
+
+        with pytest.raises(ValueError, match="not found"):
+            Hotfix(self.mock_git, self.mock_github, "1.3.0").run()
+
+    def test_run_determines_hotfix_version(self) -> None:
+        Hotfix(self.mock_git, self.mock_github, "1.3.0").run()
+
+        self.mock_git.get_next_hotfix_version.assert_called_once_with(
+            Version.parse("1.3.0")
+        )
+
+    def test_run_validates_branch_does_not_exist(self) -> None:
+        Hotfix(self.mock_git, self.mock_github, "1.3.0").run()
+
+        self.mock_github.validate_release_branch_does_not_exist.assert_called_once_with(
+            "1.3.1"
+        )
+
+    def test_run_raises_when_branch_already_exists(self) -> None:
+        self.mock_github.validate_release_branch_does_not_exist.side_effect = (
+            ValueError("already exists")
+        )
+
+        with pytest.raises(ValueError, match="already exists"):
+            Hotfix(self.mock_git, self.mock_github, "1.3.0").run()
+
+    def test_run_creates_release_branch_from_base_tag(self) -> None:
+        Hotfix(self.mock_git, self.mock_github, "1.3.0").run()
+
+        self.mock_git.create_release_branch.assert_called_once_with(
+            "1.3.1", source_ref="v1.3.0"
+        )
+
+    def test_run_calls_steps_in_correct_order(self) -> None:
+        Hotfix(self.mock_git, self.mock_github, "1.3.0").run()
+
+        github_methods = [call[0] for call in self.mock_github.method_calls]
+        git_methods = [call[0] for call in self.mock_git.method_calls]
+
+        assert github_methods.index("validate_tag_exists") < github_methods.index(
+            "validate_release_branch_does_not_exist"
+        )
+        assert git_methods.index("get_next_hotfix_version") < git_methods.index(
+            "create_release_branch"
+        )
+
+    @mock.patch.dict("os.environ", {}, clear=True)
+    def test_run_writes_summary(self, capsys: pytest.CaptureFixture[str]) -> None:
+        Hotfix(self.mock_git, self.mock_github, "1.3.0").run()
+
+        captured = capsys.readouterr()
+        assert "## Hotfix Branch Created" in captured.out
+        assert "v1.3.0" in captured.out
+        assert "1.3.1" in captured.out
+        assert "abc123" in captured.out

--- a/tests/unit/release_tools/test_tag_rc.py
+++ b/tests/unit/release_tools/test_tag_rc.py
@@ -1,0 +1,108 @@
+"""Unit tests for TagRC."""
+
+from unittest import mock
+
+import pytest
+from pytest_mock import MockerFixture
+from semver import Version
+
+from release_tools.git import GitHelper
+from release_tools.github import GitHubHelper
+from release_tools.tag_rc import TagRC
+
+
+class TestTagRC:
+    """Tests for TagRC."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, mocker: MockerFixture) -> None:
+        self.mock_git = mocker.Mock(spec_set=GitHelper)
+        self.mock_github = mocker.Mock(spec_set=GitHubHelper)
+        self.mock_git.get_next_rc_number.return_value = 3
+        self.mock_git.create_rc_tag.return_value = "v2.0.0-rc.3"
+        self.mock_git.get_head_sha.return_value = "abc123"
+        self.mock_github.create_prerelease.return_value = (
+            "https://github.com/owner/repo/releases/v2.0.0-rc.3"
+        )
+        mocker.patch(
+            "release_tools.tag_rc.ReleaseVersionHelper.parse",
+            return_value=Version.parse("2.0.0"),
+        )
+
+    def test_run_validates_branch_exists(self) -> None:
+        TagRC(self.mock_git, self.mock_github, "2.0.0").run()
+
+        self.mock_github.validate_release_branch_exists.assert_called_once_with("2.0.0")
+
+    def test_run_validates_not_finalised(self) -> None:
+        TagRC(self.mock_git, self.mock_github, "2.0.0").run()
+
+        self.mock_github.validate_not_finalised.assert_called_once_with("2.0.0")
+
+    def test_run_raises_when_branch_not_found(self) -> None:
+        self.mock_github.validate_release_branch_exists.side_effect = ValueError(
+            "not found"
+        )
+
+        with pytest.raises(ValueError, match="not found"):
+            TagRC(self.mock_git, self.mock_github, "2.0.0").run()
+
+    def test_run_raises_when_already_finalised(self) -> None:
+        self.mock_github.validate_not_finalised.side_effect = ValueError(
+            "already finalised"
+        )
+
+        with pytest.raises(ValueError, match="already finalised"):
+            TagRC(self.mock_git, self.mock_github, "2.0.0").run()
+
+    def test_run_gets_next_rc_number(self) -> None:
+        TagRC(self.mock_git, self.mock_github, "2.0.0").run()
+
+        self.mock_git.get_next_rc_number.assert_called_once_with("2.0.0")
+
+    def test_run_creates_rc_tag_with_correct_number(self) -> None:
+        TagRC(self.mock_git, self.mock_github, "2.0.0").run()
+
+        self.mock_git.create_rc_tag.assert_called_once_with("2.0.0", rc_number=3)
+
+    def test_run_creates_prerelease(self) -> None:
+        TagRC(self.mock_git, self.mock_github, "2.0.0").run()
+
+        self.mock_github.create_prerelease.assert_called_once_with(
+            "v2.0.0-rc.3",
+            "release/2.0.0",
+        )
+
+    def test_run_triggers_promotion(self) -> None:
+        TagRC(self.mock_git, self.mock_github, "2.0.0").run()
+
+        self.mock_github.trigger_promotion.assert_called_once_with(
+            "release/2.0.0",
+            "v2.0.0-rc.3",
+        )
+
+    def test_run_calls_steps_in_correct_order(self) -> None:
+        TagRC(self.mock_git, self.mock_github, "2.0.0").run()
+
+        github_methods = [call[0] for call in self.mock_github.method_calls]
+        git_methods = [call[0] for call in self.mock_git.method_calls]
+
+        assert github_methods.index(
+            "validate_release_branch_exists"
+        ) < github_methods.index("validate_not_finalised")
+        assert git_methods.index("get_next_rc_number") < git_methods.index(
+            "create_rc_tag"
+        )
+        assert github_methods.index("create_prerelease") < github_methods.index(
+            "trigger_promotion"
+        )
+
+    @mock.patch.dict("os.environ", {}, clear=True)
+    def test_run_writes_summary(self, capsys: pytest.CaptureFixture[str]) -> None:
+        TagRC(self.mock_git, self.mock_github, "2.0.0").run()
+
+        captured = capsys.readouterr()
+        assert "## New RC Tagged" in captured.out
+        assert "v2.0.0-rc.3" in captured.out
+        assert "release/2.0.0" in captured.out
+        assert "abc123" in captured.out

--- a/tests/unit/release_tools/test_validate_promotion.py
+++ b/tests/unit/release_tools/test_validate_promotion.py
@@ -1,0 +1,88 @@
+"""Unit tests for ValidatePromotion."""
+
+from unittest import mock
+
+import pytest
+from pytest_mock import MockerFixture
+from semver import Version
+
+from release_tools.github import GitHubHelper
+from release_tools.validate_promotion import ValidatePromotion
+
+
+class TestValidatePromotion:
+    """Tests for ValidatePromotion."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, mocker: MockerFixture) -> None:
+        self.mock_github = mocker.Mock(spec_set=GitHubHelper)
+        mocker.patch(
+            "release_tools.validate_promotion.ReleaseVersionHelper.parse_rc",
+            return_value=Version.parse("1.2.0-rc.1"),
+        )
+
+    def test_run_returns_normalised_tag_name(self) -> None:
+        result = ValidatePromotion(self.mock_github, "v1.2.0-rc.1").run()
+
+        assert result == "v1.2.0-rc.1"
+
+    def test_run_validates_tag_exists(self) -> None:
+        ValidatePromotion(self.mock_github, "v1.2.0-rc.1").run()
+
+        self.mock_github.validate_tag_exists.assert_called_once_with("v1.2.0-rc.1")
+
+    def test_run_validates_release_branch_exists(self) -> None:
+        ValidatePromotion(self.mock_github, "v1.2.0-rc.1").run()
+
+        self.mock_github.validate_release_branch_exists.assert_called_once_with("1.2.0")
+
+    def test_run_raises_when_invalid_rc_tag(self, mocker: MockerFixture) -> None:
+        mocker.patch(
+            "release_tools.validate_promotion.ReleaseVersionHelper.parse_rc",
+            side_effect=ValueError("RC tag"),
+        )
+
+        with pytest.raises(ValueError, match="RC tag"):
+            ValidatePromotion(self.mock_github, "1.2.0").run()
+
+    def test_run_raises_when_tag_not_found(self) -> None:
+        self.mock_github.validate_tag_exists.side_effect = ValueError("does not exist")
+
+        with pytest.raises(ValueError, match="does not exist"):
+            ValidatePromotion(self.mock_github, "v1.2.0-rc.1").run()
+
+    def test_run_raises_when_branch_not_found(self) -> None:
+        self.mock_github.validate_release_branch_exists.side_effect = ValueError(
+            "No release branch"
+        )
+
+        with pytest.raises(ValueError, match="No release branch"):
+            ValidatePromotion(self.mock_github, "v1.2.0-rc.1").run()
+
+    def test_run_checks_tag_before_branch(self) -> None:
+        ValidatePromotion(self.mock_github, "v1.2.0-rc.1").run()
+
+        methods = [call[0] for call in self.mock_github.method_calls]
+        assert methods.index("validate_tag_exists") < methods.index(
+            "validate_release_branch_exists"
+        )
+
+    @mock.patch.dict("os.environ", {}, clear=True)
+    def test_run_prints_version_when_no_github_output(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        ValidatePromotion(self.mock_github, "v1.2.0-rc.1").run()
+
+        captured = capsys.readouterr()
+        assert "version=v1.2.0-rc.1" in captured.out
+
+    def test_run_writes_to_github_output(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        output_file = tmp_path / "github_output"
+        output_file.write_text("")
+
+        with mock.patch.dict("os.environ", {"GITHUB_OUTPUT": str(output_file)}):
+            ValidatePromotion(self.mock_github, "v1.2.0-rc.1").run()
+
+        assert "version=v1.2.0-rc.1" in output_file.read_text()

--- a/tests/unit/release_tools/test_version.py
+++ b/tests/unit/release_tools/test_version.py
@@ -52,3 +52,25 @@ class TestReleaseVersionHelper:
             Version.parse("1.0.0"),
             None,
         )
+
+    def test_parse_rc_returns_version_when_valid_rc_tag(self) -> None:
+        result = ReleaseVersionHelper.parse_rc("1.2.0-rc.1")
+
+        assert result == Version.parse("1.2.0-rc.1")
+
+    def test_parse_rc_returns_version_when_v_prefix(self) -> None:
+        result = ReleaseVersionHelper.parse_rc("v1.2.0-rc.1")
+
+        assert result == Version.parse("1.2.0-rc.1")
+
+    def test_parse_rc_raises_when_stable_version(self) -> None:
+        with pytest.raises(ValueError, match="RC tag"):
+            ReleaseVersionHelper.parse_rc("1.2.0")
+
+    def test_parse_rc_raises_when_invalid_prerelease(self) -> None:
+        with pytest.raises(ValueError, match="RC tag"):
+            ReleaseVersionHelper.parse_rc("1.2.0-beta.1")
+
+    def test_parse_rc_raises_when_invalid_input(self) -> None:
+        with pytest.raises(ValueError, match="semver format"):
+            ReleaseVersionHelper.parse_rc("abc")


### PR DESCRIPTION
## Summary

- **GitHelper uses ls-remote for all remote queries** — `get_latest_stable_tag`, `get_inflight_release`, `create_final_tag` now query origin directly instead of relying on local git state, ensuring consistent behaviour on CI runners and local machines
- **Pythonized tag-rc.yml and hotfix.yml** — moved shell logic into `TagRC` and `Hotfix` orchestrator classes with invoke tasks, matching the existing pattern for `CutRelease`, `ValidatePromotion`, and `FinalisePromotion`
- **New GitHelper methods** — `get_next_rc_number` (single ls-remote, replaces shell awk/sed), `get_next_hotfix_version` (single ls-remote, replaces N-call shell loop), `_resolve_remote_tag_sha` (resolves tag to commit SHA without local fetch)
- **New GitHubHelper methods** — `validate_not_finalised`, `validate_release_branch_does_not_exist` (inverse validation helpers)
- **Removed unnecessary fetch-depth/fetch-tags** — all workflows now use default shallow clone since nothing reads local history or tags
- **`create_release_branch` and `create_final_tag` resolve source refs via ls-remote** — no longer require tags to exist in the local clone

## Test plan

- [x] `uv run pytest tests/unit/ -v` — 124 tests pass
- [x] `uv run ruff check src/ tasks/ tests/` — clean
- [x] `uv run ty check src/ tasks/` — clean
- [ ] Trigger cut-release workflow manually to verify end-to-end
- [ ] Trigger tag-rc workflow to verify RC auto-increment
- [ ] Trigger hotfix workflow to verify patch version calculation

🤖 Generated with [Claude Code](https://claude.com/claude-code)