### PR TITLE
Fix: normalise version input to strip v prefix

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -19,6 +19,12 @@ jobs:
   cut-release:
     runs-on: ubuntu-latest
     steps:
+      - name: Normalise version
+        id: version
+        run: |
+          VERSION="${{ inputs.version }}"
+          echo "value=${VERSION#v}" >> $GITHUB_OUTPUT
+
       - name: Checkout main
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -30,4 +36,4 @@ jobs:
       - name: Cut release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: uv run invoke release.cut-release --version "${{ inputs.version }}"
+        run: uv run invoke release.cut-release --version "${{ steps.version.outputs.value }}"

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -16,10 +16,16 @@ jobs:
   hotfix:
     runs-on: ubuntu-latest
     steps:
+      - name: Normalise version
+        id: version
+        run: |
+          VERSION="${{ inputs.base_version }}"
+          echo "value=${VERSION#v}" >> $GITHUB_OUTPUT
+
       - name: Checkout from base release tag
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: v${{ inputs.base_version }}
+          ref: v${{ steps.version.outputs.value }}
 
       - name: Setup Python
         uses: ./.github/actions/setup-python
@@ -27,4 +33,4 @@ jobs:
       - name: Create hotfix
         env:
           GH_TOKEN: ${{ github.token }}
-        run: uv run invoke release.hotfix --base-version "${{ inputs.base_version }}"
+        run: uv run invoke release.hotfix --base-version "${{ steps.version.outputs.value }}"

--- a/.github/workflows/tag-rc.yml
+++ b/.github/workflows/tag-rc.yml
@@ -16,10 +16,16 @@ jobs:
   tag-rc:
     runs-on: ubuntu-latest
     steps:
+      - name: Normalise version
+        id: version
+        run: |
+          VERSION="${{ inputs.version }}"
+          echo "value=${VERSION#v}" >> $GITHUB_OUTPUT
+
       - name: Checkout release branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: release/${{ inputs.version }}
+          ref: release/${{ steps.version.outputs.value }}
 
       - name: Setup Python
         uses: ./.github/actions/setup-python
@@ -27,4 +33,4 @@ jobs:
       - name: Tag RC
         env:
           GH_TOKEN: ${{ github.token }}
-        run: uv run invoke release.tag-rc --version "${{ inputs.version }}"
+        run: uv run invoke release.tag-rc --version "${{ steps.version.outputs.value }}"


### PR DESCRIPTION
## Summary

- All three workflow dispatch workflows (cut-release, tag-rc, hotfix) now strip the `v` prefix from user input before using it in checkout refs and Python commands
- Prevents checkout failures when users enter `v1.0.0` instead of `1.0.0`
- Found during test plan execution: tag-rc with `v2.0.0` tried to checkout `release/v2.0.0` which doesn't exist

## Test plan

- [ ] Rerun test 5.2 (Tag RC with v prefix) after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)