### PR TITLE
Fix: create final tag via GitHub API instead of local git

### DIFF
--- a/src/release_tools/finalise_promotion.py
+++ b/src/release_tools/finalise_promotion.py
@@ -11,9 +11,6 @@ from release_tools.version import ReleaseVersionHelper
 class FinalisePromotion:
     """Command to finalise a promoted RC into a stable release."""
 
-    _BOT_NAME = "github-actions[bot]"
-    _BOT_EMAIL = "github-actions[bot]@users.noreply.github.com"
-
     def __init__(self, git: GitHelper, github: GitHubHelper, raw_version: str) -> None:
         """Initialise with helpers and the RC tag string."""
         self._git = git
@@ -38,9 +35,9 @@ class FinalisePromotion:
 
         print(f"Finalising {rc_tag} as {final_tag}...")
 
-        self._git.configure_identity(self._BOT_NAME, self._BOT_EMAIL)
-
-        created = self._git.create_final_tag(final_tag, rc_tag)
+        created = self._github.create_final_tag(
+            final_tag, rc_tag, message=f"Release {final_tag}"
+        )
         if created:
             print(f"  Created tag {final_tag}")
         else:

--- a/src/release_tools/git.py
+++ b/src/release_tools/git.py
@@ -215,32 +215,3 @@ class GitHelper:
         with self._repo.config_writer() as config:
             config.set_value("user", "name", name)
             config.set_value("user", "email", email)
-
-    def create_final_tag(self, tag_name: str, source_ref: str) -> bool:
-        """Create an annotated release tag at *source_ref* and push it.
-
-        Resolves *source_ref* to a commit SHA via ``ls-remote`` so the
-        tag does not need to exist in the local clone.  Returns ``True``
-        if a new tag was created, ``False`` if it already existed on
-        origin.
-
-        Raises:
-            ValueError: If *source_ref* is not found on origin.
-
-        """
-        ls_remote_output = self._repo.git.ls_remote("--tags", "origin")
-        remote_tag_names = self._parse_remote_ref_names(
-            ls_remote_output, prefix="refs/tags/"
-        )
-
-        if tag_name in remote_tag_names:
-            return False
-
-        source_sha = self._resolve_remote_tag_sha(ls_remote_output, source_ref)
-        if not source_sha:
-            msg = f"Source tag {source_ref} not found on origin"
-            raise ValueError(msg)
-
-        self._repo.create_tag(tag_name, ref=source_sha, message=f"Release {tag_name}")
-        self._repo.remotes.origin.push(tag_name)
-        return True

--- a/src/release_tools/github.py
+++ b/src/release_tools/github.py
@@ -106,6 +106,48 @@ class GitHubHelper:
         msg = f"Branch {branch_name} already exists"
         raise ValueError(msg)
 
+    def create_final_tag(self, tag_name: str, source_tag: str, message: str) -> bool:
+        """Create an annotated release tag via the GitHub API.
+
+        Resolves *source_tag* to a commit SHA on the remote and creates
+        an annotated tag object plus its ref.  No local clone state is
+        needed.
+
+        Returns ``True`` if a new tag was created, ``False`` if it
+        already existed.
+
+        Raises:
+            ValueError: If *source_tag* does not exist.
+
+        """
+        try:
+            self._repo.get_git_ref(f"tags/{tag_name}")
+        except UnknownObjectException:
+            pass
+        else:
+            return False
+
+        try:
+            source_ref = self._repo.get_git_ref(f"tags/{source_tag}")
+        except UnknownObjectException:
+            msg = f"Source tag {source_tag} not found on GitHub"
+            raise ValueError(msg) from None
+
+        source_sha = source_ref.object.sha
+        # Dereference if annotated tag (points to tag object, not commit)
+        if source_ref.object.type == "tag":
+            tag_obj = self._repo.get_git_tag(source_sha)
+            source_sha = tag_obj.object.sha
+
+        git_tag = self._repo.create_git_tag(
+            tag=tag_name,
+            message=message,
+            object=source_sha,
+            type="commit",
+        )
+        self._repo.create_git_ref(ref=f"refs/tags/{tag_name}", sha=git_tag.sha)
+        return True
+
     def get_mergeback_count(self, branch: str) -> int:
         """Count commits on *branch* that are not on ``main``.
 

--- a/tests/unit/release_tools/test_finalise_promotion.py
+++ b/tests/unit/release_tools/test_finalise_promotion.py
@@ -18,7 +18,7 @@ class TestFinalisePromotion:
     def setup(self, mocker: MockerFixture) -> None:
         self.mock_git = mocker.Mock(spec_set=GitHelper)
         self.mock_github = mocker.Mock(spec_set=GitHubHelper)
-        self.mock_git.create_final_tag.return_value = True
+        self.mock_github.create_final_tag.return_value = True
         self.mock_github.get_mergeback_count.return_value = 0
         self.mock_github.find_previous_stable_release.return_value = "v1.0.0"
         self.mock_github.create_mergeback_issue.return_value = (
@@ -29,18 +29,12 @@ class TestFinalisePromotion:
             return_value=Version.parse("2.0.0-rc.1"),
         )
 
-    def test_run_configures_git_identity(self) -> None:
-        FinalisePromotion(self.mock_git, self.mock_github, "v2.0.0-rc.1").run()
-
-        self.mock_git.configure_identity.assert_called_once_with(
-            "github-actions[bot]",
-            "github-actions[bot]@users.noreply.github.com",
-        )
-
     def test_run_creates_final_tag_from_rc(self) -> None:
         FinalisePromotion(self.mock_git, self.mock_github, "v2.0.0-rc.1").run()
 
-        self.mock_git.create_final_tag.assert_called_once_with("v2.0.0", "v2.0.0-rc.1")
+        self.mock_github.create_final_tag.assert_called_once_with(
+            "v2.0.0", "v2.0.0-rc.1", message="Release v2.0.0"
+        )
 
     def test_run_finds_previous_stable_release(self) -> None:
         FinalisePromotion(self.mock_git, self.mock_github, "v2.0.0-rc.1").run()
@@ -93,11 +87,10 @@ class TestFinalisePromotion:
 
         FinalisePromotion(self.mock_git, self.mock_github, "v2.0.0-rc.1").run()
 
-        git_methods = [call[0] for call in self.mock_git.method_calls]
         github_methods = [call[0] for call in self.mock_github.method_calls]
 
-        assert git_methods.index("configure_identity") < git_methods.index(
-            "create_final_tag"
+        assert github_methods.index("create_final_tag") < github_methods.index(
+            "find_previous_stable_release"
         )
         assert github_methods.index(
             "find_previous_stable_release"

--- a/tests/unit/release_tools/test_git.py
+++ b/tests/unit/release_tools/test_git.py
@@ -284,47 +284,6 @@ class TestGitHelper:
         mock_config.set_value.assert_any_call("user", "name", "Bot")
         mock_config.set_value.assert_any_call("user", "email", "bot@example.com")
 
-    def test_create_final_tag_creates_and_pushes_when_new(self) -> None:
-        self.mock_repo.git.ls_remote.return_value = self._fake_ls_remote(
-            "refs/tags/v1.2.0-rc.1",
-        )
-
-        result = self.helper.create_final_tag("v1.2.0", "v1.2.0-rc.1")
-
-        assert result is True
-        self.mock_repo.create_tag.assert_called_once_with(
-            "v1.2.0", ref="0" * 40, message="Release v1.2.0"
-        )
-        self.mock_origin.push.assert_called_once_with("v1.2.0")
-
-    def test_create_final_tag_returns_false_when_tag_exists(self) -> None:
-        self.mock_repo.git.ls_remote.return_value = self._fake_ls_remote(
-            "refs/tags/v1.2.0",
-            "refs/tags/v1.2.0-rc.1",
-        )
-
-        result = self.helper.create_final_tag("v1.2.0", "v1.2.0-rc.1")
-
-        assert result is False
-        self.mock_repo.create_tag.assert_not_called()
-
-    def test_create_final_tag_raises_when_source_ref_not_found(self) -> None:
-        self.mock_repo.git.ls_remote.return_value = ""
-
-        with pytest.raises(ValueError, match="not found on origin"):
-            self.helper.create_final_tag("v1.2.0", "v1.2.0-rc.1")
-
-    def test_create_final_tag_prefers_dereferenced_sha(self) -> None:
-        self.mock_repo.git.ls_remote.return_value = (
-            "aaa111\trefs/tags/v1.2.0-rc.1\nbbb222\trefs/tags/v1.2.0-rc.1^{}"
-        )
-
-        self.helper.create_final_tag("v1.2.0", "v1.2.0-rc.1")
-
-        self.mock_repo.create_tag.assert_called_once_with(
-            "v1.2.0", ref="bbb222", message="Release v1.2.0"
-        )
-
     @staticmethod
     def _fake_ls_remote(*ref_paths: str) -> str:
         """Build fake ``git ls-remote`` output for the given ref paths."""

--- a/tests/unit/release_tools/test_github.py
+++ b/tests/unit/release_tools/test_github.py
@@ -136,6 +136,76 @@ class TestGitHubHelper:
         with pytest.raises(ValueError, match="already exists"):
             self.helper.validate_release_branch_does_not_exist("1.0.0")
 
+    # -- create_final_tag --
+
+    def test_create_final_tag_creates_tag_and_ref_when_new(
+        self, mocker: MockerFixture
+    ) -> None:
+        self.mock_repo.get_git_ref.side_effect = [
+            UnknownObjectException(404, {}, {}),  # tag doesn't exist
+            mocker.Mock(object=mocker.Mock(sha="abc123", type="commit")),  # source ref
+        ]
+        mock_tag = mocker.Mock(sha="tag_obj_sha")
+        self.mock_repo.create_git_tag.return_value = mock_tag
+
+        result = self.helper.create_final_tag(
+            "v1.2.0", "v1.2.0-rc.1", message="Release v1.2.0"
+        )
+
+        assert result is True
+        self.mock_repo.create_git_tag.assert_called_once_with(
+            tag="v1.2.0",
+            message="Release v1.2.0",
+            object="abc123",
+            type="commit",
+        )
+        self.mock_repo.create_git_ref.assert_called_once_with(
+            ref="refs/tags/v1.2.0", sha="tag_obj_sha"
+        )
+
+    def test_create_final_tag_returns_false_when_tag_exists(self) -> None:
+        result = self.helper.create_final_tag(
+            "v1.2.0", "v1.2.0-rc.1", message="Release v1.2.0"
+        )
+
+        assert result is False
+        self.mock_repo.create_git_tag.assert_not_called()
+
+    def test_create_final_tag_raises_when_source_tag_not_found(self) -> None:
+        self.mock_repo.get_git_ref.side_effect = [
+            UnknownObjectException(404, {}, {}),  # tag doesn't exist
+            UnknownObjectException(404, {}, {}),  # source tag not found
+        ]
+
+        with pytest.raises(ValueError, match="not found on GitHub"):
+            self.helper.create_final_tag(
+                "v1.2.0", "v1.2.0-rc.1", message="Release v1.2.0"
+            )
+
+    def test_create_final_tag_dereferences_annotated_source_tag(
+        self, mocker: MockerFixture
+    ) -> None:
+        tag_object = mocker.Mock(sha="tag_obj_sha", type="tag")
+        self.mock_repo.get_git_ref.side_effect = [
+            UnknownObjectException(404, {}, {}),  # tag doesn't exist
+            mocker.Mock(object=tag_object),  # source ref is annotated tag
+        ]
+        self.mock_repo.get_git_tag.return_value = mocker.Mock(
+            object=mocker.Mock(sha="commit_sha")
+        )
+        mock_tag = mocker.Mock(sha="new_tag_sha")
+        self.mock_repo.create_git_tag.return_value = mock_tag
+
+        self.helper.create_final_tag("v1.2.0", "v1.2.0-rc.1", message="Release v1.2.0")
+
+        self.mock_repo.get_git_tag.assert_called_once_with("tag_obj_sha")
+        self.mock_repo.create_git_tag.assert_called_once_with(
+            tag="v1.2.0",
+            message="Release v1.2.0",
+            object="commit_sha",
+            type="commit",
+        )
+
     # -- get_mergeback_count --
 
     def test_get_mergeback_count_returns_ahead_by(self, mocker: MockerFixture) -> None:


### PR DESCRIPTION
## Summary

- Moved `create_final_tag` from `GitHelper` (local git) to `GitHubHelper` (GitHub API)
- Uses `create_git_tag` + `create_git_ref` API calls to create annotated tags remotely
- Handles both lightweight and annotated source tags (dereferences annotated tags to commit SHA)
- Removes `configure_identity` and bot constants from `FinalisePromotion` (no longer needed)
- Fixes: finalise step failed on shallow CI clones because `git tag` couldn't resolve the RC tag SHA locally

## Test plan

- [x] 123 unit tests pass
- [x] ruff check + format clean
- [ ] Rerun promote pipeline for v2.0.0 to verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)