### PR TITLE
Fix: hotfix version calculation checks release branches

### DIFF
--- a/src/release_tools/git.py
+++ b/src/release_tools/git.py
@@ -135,29 +135,42 @@ class GitHelper:
     def get_next_hotfix_version(self, base_version: Version) -> Version:
         """Return the next available hotfix version for *base_version*.
 
-        Scans all remote tags in a single ``ls-remote`` call to find
-        the highest patch number in use for the same ``major.minor``
-        series (counting both stable tags and RC tags as "used"),
-        then returns the next patch version.
+        Scans remote tags and release branches to find the highest
+        patch number in use for the same ``major.minor`` series.
+        Tags (both stable and RC) and ``release/`` branches all
+        count as "used", then returns the next patch version.
         """
-        ls_remote_output = self._repo.git.ls_remote("--tags", "origin")
+        ls_remote_tags = self._repo.git.ls_remote("--tags", "origin")
         remote_tag_names = self._parse_remote_ref_names(
-            ls_remote_output, prefix="refs/tags/"
+            ls_remote_tags, prefix="refs/tags/"
         )
 
-        version_prefix = f"v{base_version.major}.{base_version.minor}."
-        patch_pattern = re.compile(
+        ls_remote_heads = self._repo.git.ls_remote("--heads", "origin")
+        remote_branch_names = self._parse_remote_ref_names(
+            ls_remote_heads, prefix="refs/heads/"
+        )
+
+        tag_prefix = f"v{base_version.major}.{base_version.minor}."
+        tag_pattern = re.compile(
             rf"^v{base_version.major}\.{base_version.minor}\.(\d+)(?:-rc\.\d+)?$"
         )
+        branch_prefix = f"release/{base_version.major}.{base_version.minor}."
 
         highest_patch = base_version.patch
         for tag_name in remote_tag_names:
-            if not tag_name.startswith(version_prefix):
+            if not tag_name.startswith(tag_prefix):
                 continue
-            match = patch_pattern.match(tag_name)
+            match = tag_pattern.match(tag_name)
             if match:
                 patch = int(match.group(1))
                 highest_patch = max(highest_patch, patch)
+
+        for branch_name in remote_branch_names:
+            if not branch_name.startswith(branch_prefix):
+                continue
+            patch_str = branch_name.removeprefix(branch_prefix)
+            if patch_str.isdigit():
+                highest_patch = max(highest_patch, int(patch_str))
 
         return Version(base_version.major, base_version.minor, highest_patch + 1)
 

--- a/tests/unit/release_tools/test_git.py
+++ b/tests/unit/release_tools/test_git.py
@@ -144,29 +144,30 @@ class TestGitHelper:
     def test_get_next_hotfix_version_returns_patch_plus_1_when_no_higher(
         self,
     ) -> None:
-        self.mock_repo.git.ls_remote.return_value = self._fake_ls_remote(
-            "refs/tags/v1.3.0",
-        )
+        self.mock_repo.git.ls_remote.side_effect = [
+            self._fake_ls_remote("refs/tags/v1.3.0"),
+            "",
+        ]
 
         result = self.helper.get_next_hotfix_version(Version.parse("1.3.0"))
 
         assert result == Version(1, 3, 1)
 
     def test_get_next_hotfix_version_skips_existing_stable_patches(self) -> None:
-        self.mock_repo.git.ls_remote.return_value = self._fake_ls_remote(
-            "refs/tags/v1.3.0",
-            "refs/tags/v1.3.1",
-        )
+        self.mock_repo.git.ls_remote.side_effect = [
+            self._fake_ls_remote("refs/tags/v1.3.0", "refs/tags/v1.3.1"),
+            "",
+        ]
 
         result = self.helper.get_next_hotfix_version(Version.parse("1.3.0"))
 
         assert result == Version(1, 3, 2)
 
     def test_get_next_hotfix_version_skips_existing_rc_patches(self) -> None:
-        self.mock_repo.git.ls_remote.return_value = self._fake_ls_remote(
-            "refs/tags/v1.3.0",
-            "refs/tags/v1.3.1-rc.1",
-        )
+        self.mock_repo.git.ls_remote.side_effect = [
+            self._fake_ls_remote("refs/tags/v1.3.0", "refs/tags/v1.3.1-rc.1"),
+            "",
+        ]
 
         result = self.helper.get_next_hotfix_version(Version.parse("1.3.0"))
 
@@ -175,35 +176,56 @@ class TestGitHelper:
     def test_get_next_hotfix_version_finds_highest_across_stable_and_rc(
         self,
     ) -> None:
-        self.mock_repo.git.ls_remote.return_value = self._fake_ls_remote(
-            "refs/tags/v1.3.0",
-            "refs/tags/v1.3.1",
-            "refs/tags/v1.3.2-rc.1",
-        )
+        self.mock_repo.git.ls_remote.side_effect = [
+            self._fake_ls_remote(
+                "refs/tags/v1.3.0", "refs/tags/v1.3.1", "refs/tags/v1.3.2-rc.1"
+            ),
+            "",
+        ]
 
         result = self.helper.get_next_hotfix_version(Version.parse("1.3.0"))
 
         assert result == Version(1, 3, 3)
 
     def test_get_next_hotfix_version_ignores_other_minor_versions(self) -> None:
-        self.mock_repo.git.ls_remote.return_value = self._fake_ls_remote(
-            "refs/tags/v1.3.0",
-            "refs/tags/v1.4.1",
-        )
+        self.mock_repo.git.ls_remote.side_effect = [
+            self._fake_ls_remote("refs/tags/v1.3.0", "refs/tags/v1.4.1"),
+            "",
+        ]
 
         result = self.helper.get_next_hotfix_version(Version.parse("1.3.0"))
 
         assert result == Version(1, 3, 1)
 
     def test_get_next_hotfix_version_ignores_other_major_versions(self) -> None:
-        self.mock_repo.git.ls_remote.return_value = self._fake_ls_remote(
-            "refs/tags/v1.3.0",
-            "refs/tags/v2.3.1",
-        )
+        self.mock_repo.git.ls_remote.side_effect = [
+            self._fake_ls_remote("refs/tags/v1.3.0", "refs/tags/v2.3.1"),
+            "",
+        ]
 
         result = self.helper.get_next_hotfix_version(Version.parse("1.3.0"))
 
         assert result == Version(1, 3, 1)
+
+    def test_get_next_hotfix_version_skips_existing_release_branches(self) -> None:
+        self.mock_repo.git.ls_remote.side_effect = [
+            self._fake_ls_remote("refs/tags/v1.3.0"),
+            self._fake_ls_remote("refs/heads/release/1.3.1"),
+        ]
+
+        result = self.helper.get_next_hotfix_version(Version.parse("1.3.0"))
+
+        assert result == Version(1, 3, 2)
+
+    def test_get_next_hotfix_version_considers_both_tags_and_branches(self) -> None:
+        self.mock_repo.git.ls_remote.side_effect = [
+            self._fake_ls_remote("refs/tags/v1.3.0", "refs/tags/v1.3.1"),
+            self._fake_ls_remote("refs/heads/release/1.3.2"),
+        ]
+
+        result = self.helper.get_next_hotfix_version(Version.parse("1.3.0"))
+
+        assert result == Version(1, 3, 3)
 
     def test_create_release_branch_creates_and_pushes_branch(self) -> None:
         mock_branch = self.mock_repo.create_head.return_value


### PR DESCRIPTION
## Summary

- `get_next_hotfix_version` now scans both remote tags AND release branches when determining the next available patch
- Previously only checked tags, so `release/1.0.1` without any tags was not detected as "used"
- Found during test plan execution: hotfix on v1.0.0 returned 1.0.1 even though `release/1.0.1` already existed

## Test plan

- [x] 125 unit tests pass (2 new tests for branch scanning)
- [x] ruff check + format clean
- [ ] Rerun test 7.4 (hotfix branch already exists) — should now skip to 1.0.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)