### PR TITLE
Fix: all workflows checkout main, RC tags via GitHub API

### DIFF
--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -22,10 +22,10 @@ jobs:
           VERSION="${{ inputs.base_version }}"
           echo "value=${VERSION#v}" >> $GITHUB_OUTPUT
 
-      - name: Checkout from base release tag
+      - name: Checkout main
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: v${{ steps.version.outputs.value }}
+          ref: main
 
       - name: Setup Python
         uses: ./.github/actions/setup-python

--- a/.github/workflows/tag-rc.yml
+++ b/.github/workflows/tag-rc.yml
@@ -22,10 +22,10 @@ jobs:
           VERSION="${{ inputs.version }}"
           echo "value=${VERSION#v}" >> $GITHUB_OUTPUT
 
-      - name: Checkout release branch
+      - name: Checkout main
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: release/${{ steps.version.outputs.value }}
+          ref: main
 
       - name: Setup Python
         uses: ./.github/actions/setup-python

--- a/src/release_tools/cut_release.py
+++ b/src/release_tools/cut_release.py
@@ -39,7 +39,7 @@ class CutRelease:
         self._git.create_release_branch(version_str)
 
         print(f"Creating RC tag v{version_str}-rc.1...")
-        tag_name = self._git.create_rc_tag(version_str)
+        tag_name = self._github.create_rc_tag(version_str, branch)
 
         previous_tag = f"v{latest}" if latest else None
         print(f"Publishing pre-release {tag_name}...")

--- a/src/release_tools/git.py
+++ b/src/release_tools/git.py
@@ -199,16 +199,6 @@ class GitHelper:
             branch = self._repo.create_head(f"release/{version}")
         self._repo.remotes.origin.push(branch.name)
 
-    def create_rc_tag(self, version: str, rc_number: int = 1) -> str:
-        """Create an RC tag and push it to origin.
-
-        Returns the tag name.
-        """
-        tag_name = f"v{version}-rc.{rc_number}"
-        self._repo.create_tag(tag_name)
-        self._repo.remotes.origin.push(tag_name)
-        return tag_name
-
     def get_repo_name(self) -> str:
         """Derive the GitHub ``owner/repo`` name from the origin URL."""
         origin_url = self._repo.remotes.origin.url

--- a/src/release_tools/github.py
+++ b/src/release_tools/github.py
@@ -36,6 +36,20 @@ class GitHubHelper:
         )
         return release.html_url
 
+    def create_rc_tag(
+        self, version: str, target_branch: str, rc_number: int = 1
+    ) -> str:
+        """Create a lightweight RC tag via the GitHub API.
+
+        Resolves *target_branch* to its tip commit and creates a tag
+        ref pointing at it.  Returns the tag name.
+        """
+        tag_name = f"v{version}-rc.{rc_number}"
+        branch_ref = self._repo.get_branch(target_branch)
+        commit_sha = branch_ref.commit.sha
+        self._repo.create_git_ref(ref=f"refs/tags/{tag_name}", sha=commit_sha)
+        return tag_name
+
     def trigger_promotion(self, branch: str, tag_name: str) -> None:
         """Trigger the promote workflow on the given branch."""
         workflow = self._repo.get_workflow("promote.yml")

--- a/src/release_tools/tag_rc.py
+++ b/src/release_tools/tag_rc.py
@@ -28,7 +28,7 @@ class TagRC:
         rc_number = self._git.get_next_rc_number(version_str)
         print(f"Next RC number: {rc_number}")
 
-        tag_name = self._git.create_rc_tag(version_str, rc_number=rc_number)
+        tag_name = self._github.create_rc_tag(version_str, branch, rc_number=rc_number)
         print(f"Created tag {tag_name}")
 
         url = self._github.create_prerelease(tag_name, branch)

--- a/tests/unit/release_tools/test_cut_release.py
+++ b/tests/unit/release_tools/test_cut_release.py
@@ -20,8 +20,8 @@ class TestCutRelease:
         self.mock_github = mocker.Mock(spec_set=GitHubHelper)
         self.mock_git.get_latest_stable_tag.return_value = Version.parse("1.0.0")
         self.mock_git.get_inflight_release.return_value = None
-        self.mock_git.create_rc_tag.return_value = "v2.0.0-rc.1"
         self.mock_git.get_head_sha.return_value = "abc123"
+        self.mock_github.create_rc_tag.return_value = "v2.0.0-rc.1"
         mocker.patch(
             "release_tools.cut_release.ReleaseVersionHelper.parse",
             return_value=Version.parse("2.0.0"),
@@ -34,7 +34,7 @@ class TestCutRelease:
         CutRelease(self.mock_git, self.mock_github, "2.0.0").run()
 
         self.mock_git.create_release_branch.assert_called_once_with("2.0.0")
-        self.mock_git.create_rc_tag.assert_called_once_with("2.0.0")
+        self.mock_github.create_rc_tag.assert_called_once_with("2.0.0", "release/2.0.0")
 
     def test_run_raises_when_version_not_higher(self, mocker: MockerFixture) -> None:
         mocker.patch(
@@ -92,11 +92,10 @@ class TestCutRelease:
     def test_run_calls_steps_in_correct_order(self) -> None:
         CutRelease(self.mock_git, self.mock_github, "2.0.0").run()
 
-        git_methods = [c[0] for c in self.mock_git.method_calls]
         github_methods = [c[0] for c in self.mock_github.method_calls]
 
-        assert git_methods.index("create_release_branch") < git_methods.index(
-            "create_rc_tag"
+        assert github_methods.index("create_rc_tag") < github_methods.index(
+            "create_prerelease"
         )
         assert github_methods.index("create_prerelease") < github_methods.index(
             "trigger_promotion"

--- a/tests/unit/release_tools/test_git.py
+++ b/tests/unit/release_tools/test_git.py
@@ -256,23 +256,6 @@ class TestGitHelper:
         with pytest.raises(ValueError, match="not found on origin"):
             self.helper.create_release_branch("1.3.1", source_ref="v1.3.0")
 
-    def test_create_rc_tag_creates_and_pushes_tag(self) -> None:
-        self.helper.create_rc_tag("1.2.0")
-
-        self.mock_repo.create_tag.assert_called_once_with("v1.2.0-rc.1")
-        self.mock_origin.push.assert_called_once_with("v1.2.0-rc.1")
-
-    def test_create_rc_tag_returns_tag_name(self) -> None:
-        result = self.helper.create_rc_tag("1.2.0")
-
-        assert result == "v1.2.0-rc.1"
-
-    def test_create_rc_tag_uses_custom_rc_number(self) -> None:
-        result = self.helper.create_rc_tag("1.2.0", rc_number=3)
-
-        assert result == "v1.2.0-rc.3"
-        self.mock_repo.create_tag.assert_called_once_with("v1.2.0-rc.3")
-
     def test_get_repo_name_parses_ssh_url(self) -> None:
         self.mock_origin.url = "git@github.com:owner/repo.git"
 

--- a/tests/unit/release_tools/test_github.py
+++ b/tests/unit/release_tools/test_github.py
@@ -64,6 +64,37 @@ class TestGitHubHelper:
 
         assert result == "https://github.com/owner/repo/releases/v1.0.0-rc.1"
 
+    # -- create_rc_tag --
+
+    def test_create_rc_tag_creates_ref_at_branch_tip(
+        self, mocker: MockerFixture
+    ) -> None:
+        mock_branch = mocker.Mock()
+        mock_branch.commit.sha = "abc123"
+        self.mock_repo.get_branch.return_value = mock_branch
+
+        result = self.helper.create_rc_tag("1.2.0", "release/1.2.0")
+
+        assert result == "v1.2.0-rc.1"
+        self.mock_repo.get_branch.assert_called_once_with("release/1.2.0")
+        self.mock_repo.create_git_ref.assert_called_once_with(
+            ref="refs/tags/v1.2.0-rc.1", sha="abc123"
+        )
+
+    def test_create_rc_tag_uses_custom_rc_number(self, mocker: MockerFixture) -> None:
+        mock_branch = mocker.Mock()
+        mock_branch.commit.sha = "abc123"
+        self.mock_repo.get_branch.return_value = mock_branch
+
+        result = self.helper.create_rc_tag("1.2.0", "release/1.2.0", rc_number=3)
+
+        assert result == "v1.2.0-rc.3"
+        self.mock_repo.create_git_ref.assert_called_once_with(
+            ref="refs/tags/v1.2.0-rc.3", sha="abc123"
+        )
+
+    # -- trigger_promotion --
+
     def test_trigger_promotion_dispatches_workflow(self) -> None:
         self.helper.trigger_promotion("release/1.0.0", "v1.0.0-rc.1")
 

--- a/tests/unit/release_tools/test_tag_rc.py
+++ b/tests/unit/release_tools/test_tag_rc.py
@@ -19,8 +19,8 @@ class TestTagRC:
         self.mock_git = mocker.Mock(spec_set=GitHelper)
         self.mock_github = mocker.Mock(spec_set=GitHubHelper)
         self.mock_git.get_next_rc_number.return_value = 3
-        self.mock_git.create_rc_tag.return_value = "v2.0.0-rc.3"
         self.mock_git.get_head_sha.return_value = "abc123"
+        self.mock_github.create_rc_tag.return_value = "v2.0.0-rc.3"
         self.mock_github.create_prerelease.return_value = (
             "https://github.com/owner/repo/releases/v2.0.0-rc.3"
         )
@@ -63,7 +63,9 @@ class TestTagRC:
     def test_run_creates_rc_tag_with_correct_number(self) -> None:
         TagRC(self.mock_git, self.mock_github, "2.0.0").run()
 
-        self.mock_git.create_rc_tag.assert_called_once_with("2.0.0", rc_number=3)
+        self.mock_github.create_rc_tag.assert_called_once_with(
+            "2.0.0", "release/2.0.0", rc_number=3
+        )
 
     def test_run_creates_prerelease(self) -> None:
         TagRC(self.mock_git, self.mock_github, "2.0.0").run()
@@ -85,13 +87,12 @@ class TestTagRC:
         TagRC(self.mock_git, self.mock_github, "2.0.0").run()
 
         github_methods = [call[0] for call in self.mock_github.method_calls]
-        git_methods = [call[0] for call in self.mock_git.method_calls]
 
         assert github_methods.index(
             "validate_release_branch_exists"
         ) < github_methods.index("validate_not_finalised")
-        assert git_methods.index("get_next_rc_number") < git_methods.index(
-            "create_rc_tag"
+        assert github_methods.index("create_rc_tag") < github_methods.index(
+            "create_prerelease"
         )
         assert github_methods.index("create_prerelease") < github_methods.index(
             "trigger_promotion"


### PR DESCRIPTION
## Summary

- **All workflows now checkout main** — ensures the latest Python tooling is always used, regardless of which release branch or tag is being operated on
- **Moved `create_rc_tag` from GitHelper to GitHubHelper** — creates lightweight tags via the GitHub API by resolving the branch tip commit, so no local checkout of the release branch is needed
- **tag-rc.yml**: changed from `ref: release/{version}` to `ref: main`
- **hotfix.yml**: changed from `ref: v{base_version}` to `ref: main`

This fixes the issue where tooling bug fixes merged to main wouldn't take effect in tag-rc or hotfix workflows because they checked out older branches/tags.

## Test plan

- [x] 124 unit tests pass
- [x] ruff check + format clean
- [ ] Rerun test 7.4 (hotfix with branch already exists) — should now skip to 1.0.2
- [ ] Rerun test 5.2 (tag RC with v prefix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)