### PR TITLE
Fix: move all ref-creating operations to GitHub API

### DIFF
--- a/src/release_tools/cut_release.py
+++ b/src/release_tools/cut_release.py
@@ -39,7 +39,7 @@ class CutRelease:
         self._git.create_release_branch(version_str)
 
         print(f"Creating RC tag v{version_str}-rc.1...")
-        tag_name = self._github.create_rc_tag(version_str, branch)
+        tag_name, commit_sha = self._github.create_rc_tag(version_str, branch)
 
         previous_tag = f"v{latest}" if latest else None
         print(f"Publishing pre-release {tag_name}...")
@@ -48,7 +48,6 @@ class CutRelease:
         print("Triggering promotion pipeline...")
         self._github.trigger_promotion(branch, tag_name)
 
-        commit_sha = self._git.get_head_sha()
         self._write_summary(version_str, tag_name, commit_sha)
 
     @staticmethod

--- a/src/release_tools/git.py
+++ b/src/release_tools/git.py
@@ -174,29 +174,9 @@ class GitHelper:
 
         return Version(base_version.major, base_version.minor, highest_patch + 1)
 
-    def create_release_branch(
-        self, version: str, source_ref: str | None = None
-    ) -> None:
-        """Create a ``release/{version}`` branch and push it to origin.
-
-        If *source_ref* is provided, it is resolved to a commit SHA
-        via ``ls-remote`` so it does not need to exist in the local
-        clone.  This is used for hotfixes that branch from a stable
-        tag.
-
-        Raises:
-            ValueError: If *source_ref* is not found on origin.
-
-        """
-        if source_ref:
-            ls_remote_output = self._repo.git.ls_remote("--tags", "origin")
-            source_sha = self._resolve_remote_tag_sha(ls_remote_output, source_ref)
-            if not source_sha:
-                msg = f"Source tag {source_ref} not found on origin"
-                raise ValueError(msg)
-            branch = self._repo.create_head(f"release/{version}", commit=source_sha)
-        else:
-            branch = self._repo.create_head(f"release/{version}")
+    def create_release_branch(self, version: str) -> None:
+        """Create a ``release/{version}`` branch from HEAD and push it."""
+        branch = self._repo.create_head(f"release/{version}")
         self._repo.remotes.origin.push(branch.name)
 
     def get_repo_name(self) -> str:
@@ -208,13 +188,3 @@ class GitHelper:
         if ":" in cleaned and not cleaned.startswith("http"):
             return cleaned.split(":")[-1]
         return "/".join(cleaned.split("/")[-2:])
-
-    def get_head_sha(self) -> str:
-        """Return the SHA of the current HEAD commit."""
-        return self._repo.head.commit.hexsha
-
-    def configure_identity(self, name: str, email: str) -> None:
-        """Set the git user name and email for the repo."""
-        with self._repo.config_writer() as config:
-            config.set_value("user", "name", name)
-            config.set_value("user", "email", email)

--- a/src/release_tools/github.py
+++ b/src/release_tools/github.py
@@ -38,17 +38,41 @@ class GitHubHelper:
 
     def create_rc_tag(
         self, version: str, target_branch: str, rc_number: int = 1
-    ) -> str:
+    ) -> tuple[str, str]:
         """Create a lightweight RC tag via the GitHub API.
 
         Resolves *target_branch* to its tip commit and creates a tag
-        ref pointing at it.  Returns the tag name.
+        ref pointing at it.  Returns ``(tag_name, commit_sha)``.
         """
         tag_name = f"v{version}-rc.{rc_number}"
         branch_ref = self._repo.get_branch(target_branch)
         commit_sha = branch_ref.commit.sha
         self._repo.create_git_ref(ref=f"refs/tags/{tag_name}", sha=commit_sha)
-        return tag_name
+        return tag_name, commit_sha
+
+    def create_release_branch(self, version: str, source_tag: str) -> str:
+        """Create a release branch via the GitHub API.
+
+        Resolves *source_tag* to its commit SHA and creates the
+        branch ref.  Returns the commit SHA the branch points to.
+
+        Raises:
+            ValueError: If *source_tag* does not exist.
+
+        """
+        try:
+            source_ref = self._repo.get_git_ref(f"tags/{source_tag}")
+        except UnknownObjectException:
+            msg = f"Source tag {source_tag} not found on GitHub"
+            raise ValueError(msg) from None
+
+        source_sha = source_ref.object.sha
+        if source_ref.object.type == "tag":
+            tag_obj = self._repo.get_git_tag(source_sha)
+            source_sha = tag_obj.object.sha
+
+        self._repo.create_git_ref(ref=f"refs/heads/release/{version}", sha=source_sha)
+        return source_sha
 
     def trigger_promotion(self, branch: str, tag_name: str) -> None:
         """Trigger the promote workflow on the given branch."""

--- a/src/release_tools/hotfix.py
+++ b/src/release_tools/hotfix.py
@@ -32,10 +32,11 @@ class Hotfix:
 
         self._github.validate_release_branch_does_not_exist(hotfix_version_str)
 
-        self._git.create_release_branch(hotfix_version_str, source_ref=base_tag)
+        commit_sha = self._github.create_release_branch(
+            hotfix_version_str, source_tag=base_tag
+        )
         print(f"Created branch release/{hotfix_version_str} from {base_tag}")
 
-        commit_sha = self._git.get_head_sha()
         self._write_summary(base_version_str, hotfix_version_str, commit_sha)
 
     @staticmethod

--- a/src/release_tools/tag_rc.py
+++ b/src/release_tools/tag_rc.py
@@ -28,7 +28,9 @@ class TagRC:
         rc_number = self._git.get_next_rc_number(version_str)
         print(f"Next RC number: {rc_number}")
 
-        tag_name = self._github.create_rc_tag(version_str, branch, rc_number=rc_number)
+        tag_name, commit_sha = self._github.create_rc_tag(
+            version_str, branch, rc_number=rc_number
+        )
         print(f"Created tag {tag_name}")
 
         url = self._github.create_prerelease(tag_name, branch)
@@ -37,7 +39,6 @@ class TagRC:
         self._github.trigger_promotion(branch, tag_name)
         print(f"Promotion pipeline triggered for {tag_name}")
 
-        commit_sha = self._git.get_head_sha()
         self._write_summary(version_str, tag_name, commit_sha)
 
     @staticmethod

--- a/tests/unit/release_tools/test_cut_release.py
+++ b/tests/unit/release_tools/test_cut_release.py
@@ -20,8 +20,7 @@ class TestCutRelease:
         self.mock_github = mocker.Mock(spec_set=GitHubHelper)
         self.mock_git.get_latest_stable_tag.return_value = Version.parse("1.0.0")
         self.mock_git.get_inflight_release.return_value = None
-        self.mock_git.get_head_sha.return_value = "abc123"
-        self.mock_github.create_rc_tag.return_value = "v2.0.0-rc.1"
+        self.mock_github.create_rc_tag.return_value = ("v2.0.0-rc.1", "abc123")
         mocker.patch(
             "release_tools.cut_release.ReleaseVersionHelper.parse",
             return_value=Version.parse("2.0.0"),

--- a/tests/unit/release_tools/test_git.py
+++ b/tests/unit/release_tools/test_git.py
@@ -236,26 +236,6 @@ class TestGitHelper:
         self.mock_repo.create_head.assert_called_once_with("release/1.2.0")
         self.mock_origin.push.assert_called_once_with("release/1.2.0")
 
-    def test_create_release_branch_with_source_ref(self) -> None:
-        mock_branch = self.mock_repo.create_head.return_value
-        mock_branch.name = "release/1.3.1"
-        self.mock_repo.git.ls_remote.return_value = self._fake_ls_remote(
-            "refs/tags/v1.3.0",
-        )
-
-        self.helper.create_release_branch("1.3.1", source_ref="v1.3.0")
-
-        self.mock_repo.create_head.assert_called_once_with(
-            "release/1.3.1", commit="0" * 40
-        )
-        self.mock_origin.push.assert_called_once_with("release/1.3.1")
-
-    def test_create_release_branch_raises_when_source_ref_not_found(self) -> None:
-        self.mock_repo.git.ls_remote.return_value = ""
-
-        with pytest.raises(ValueError, match="not found on origin"):
-            self.helper.create_release_branch("1.3.1", source_ref="v1.3.0")
-
     def test_get_repo_name_parses_ssh_url(self) -> None:
         self.mock_origin.url = "git@github.com:owner/repo.git"
 
@@ -269,25 +249,6 @@ class TestGitHelper:
         result = self.helper.get_repo_name()
 
         assert result == "owner/repo"
-
-    def test_get_head_sha_returns_commit_hexsha(self) -> None:
-        self.mock_repo.head.commit.hexsha = "abc123def456"
-
-        result = self.helper.get_head_sha()
-
-        assert result == "abc123def456"
-
-    def test_configure_identity_sets_user_name_and_email(
-        self, mocker: MockerFixture
-    ) -> None:
-        mock_writer = mocker.MagicMock()
-        self.mock_repo.config_writer.return_value = mock_writer
-        mock_config = mock_writer.__enter__.return_value
-
-        self.helper.configure_identity("Bot", "bot@example.com")
-
-        mock_config.set_value.assert_any_call("user", "name", "Bot")
-        mock_config.set_value.assert_any_call("user", "email", "bot@example.com")
 
     @staticmethod
     def _fake_ls_remote(*ref_paths: str) -> str:

--- a/tests/unit/release_tools/test_github.py
+++ b/tests/unit/release_tools/test_github.py
@@ -73,9 +73,10 @@ class TestGitHubHelper:
         mock_branch.commit.sha = "abc123"
         self.mock_repo.get_branch.return_value = mock_branch
 
-        result = self.helper.create_rc_tag("1.2.0", "release/1.2.0")
+        tag_name, commit_sha = self.helper.create_rc_tag("1.2.0", "release/1.2.0")
 
-        assert result == "v1.2.0-rc.1"
+        assert tag_name == "v1.2.0-rc.1"
+        assert commit_sha == "abc123"
         self.mock_repo.get_branch.assert_called_once_with("release/1.2.0")
         self.mock_repo.create_git_ref.assert_called_once_with(
             ref="refs/tags/v1.2.0-rc.1", sha="abc123"
@@ -86,12 +87,48 @@ class TestGitHubHelper:
         mock_branch.commit.sha = "abc123"
         self.mock_repo.get_branch.return_value = mock_branch
 
-        result = self.helper.create_rc_tag("1.2.0", "release/1.2.0", rc_number=3)
+        tag_name, _ = self.helper.create_rc_tag("1.2.0", "release/1.2.0", rc_number=3)
 
-        assert result == "v1.2.0-rc.3"
+        assert tag_name == "v1.2.0-rc.3"
         self.mock_repo.create_git_ref.assert_called_once_with(
             ref="refs/tags/v1.2.0-rc.3", sha="abc123"
         )
+
+    # -- create_release_branch --
+
+    def test_create_release_branch_creates_ref_from_tag(
+        self, mocker: MockerFixture
+    ) -> None:
+        source_ref = mocker.Mock(object=mocker.Mock(sha="abc123", type="commit"))
+        self.mock_repo.get_git_ref.return_value = source_ref
+
+        commit_sha = self.helper.create_release_branch("1.3.1", source_tag="v1.3.0")
+
+        assert commit_sha == "abc123"
+        self.mock_repo.get_git_ref.assert_called_once_with("tags/v1.3.0")
+        self.mock_repo.create_git_ref.assert_called_once_with(
+            ref="refs/heads/release/1.3.1", sha="abc123"
+        )
+
+    def test_create_release_branch_dereferences_annotated_tag(
+        self, mocker: MockerFixture
+    ) -> None:
+        tag_object = mocker.Mock(sha="tag_obj_sha", type="tag")
+        self.mock_repo.get_git_ref.return_value = mocker.Mock(object=tag_object)
+        self.mock_repo.get_git_tag.return_value = mocker.Mock(
+            object=mocker.Mock(sha="commit_sha")
+        )
+
+        commit_sha = self.helper.create_release_branch("1.3.1", source_tag="v1.3.0")
+
+        assert commit_sha == "commit_sha"
+        self.mock_repo.get_git_tag.assert_called_once_with("tag_obj_sha")
+
+    def test_create_release_branch_raises_when_tag_not_found(self) -> None:
+        self.mock_repo.get_git_ref.side_effect = UnknownObjectException(404, {}, {})
+
+        with pytest.raises(ValueError, match="not found on GitHub"):
+            self.helper.create_release_branch("1.3.1", source_tag="v9.9.9")
 
     # -- trigger_promotion --
 

--- a/tests/unit/release_tools/test_hotfix.py
+++ b/tests/unit/release_tools/test_hotfix.py
@@ -19,7 +19,7 @@ class TestHotfix:
         self.mock_git = mocker.Mock(spec_set=GitHelper)
         self.mock_github = mocker.Mock(spec_set=GitHubHelper)
         self.mock_git.get_next_hotfix_version.return_value = Version.parse("1.3.1")
-        self.mock_git.get_head_sha.return_value = "abc123"
+        self.mock_github.create_release_branch.return_value = "abc123"
         mocker.patch(
             "release_tools.hotfix.ReleaseVersionHelper.parse",
             return_value=Version.parse("1.3.0"),
@@ -61,22 +61,21 @@ class TestHotfix:
     def test_run_creates_release_branch_from_base_tag(self) -> None:
         Hotfix(self.mock_git, self.mock_github, "1.3.0").run()
 
-        self.mock_git.create_release_branch.assert_called_once_with(
-            "1.3.1", source_ref="v1.3.0"
+        self.mock_github.create_release_branch.assert_called_once_with(
+            "1.3.1", source_tag="v1.3.0"
         )
 
     def test_run_calls_steps_in_correct_order(self) -> None:
         Hotfix(self.mock_git, self.mock_github, "1.3.0").run()
 
         github_methods = [call[0] for call in self.mock_github.method_calls]
-        git_methods = [call[0] for call in self.mock_git.method_calls]
 
         assert github_methods.index("validate_tag_exists") < github_methods.index(
             "validate_release_branch_does_not_exist"
         )
-        assert git_methods.index("get_next_hotfix_version") < git_methods.index(
-            "create_release_branch"
-        )
+        assert github_methods.index(
+            "validate_release_branch_does_not_exist"
+        ) < github_methods.index("create_release_branch")
 
     @mock.patch.dict("os.environ", {}, clear=True)
     def test_run_writes_summary(self, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/unit/release_tools/test_tag_rc.py
+++ b/tests/unit/release_tools/test_tag_rc.py
@@ -19,8 +19,7 @@ class TestTagRC:
         self.mock_git = mocker.Mock(spec_set=GitHelper)
         self.mock_github = mocker.Mock(spec_set=GitHubHelper)
         self.mock_git.get_next_rc_number.return_value = 3
-        self.mock_git.get_head_sha.return_value = "abc123"
-        self.mock_github.create_rc_tag.return_value = "v2.0.0-rc.3"
+        self.mock_github.create_rc_tag.return_value = ("v2.0.0-rc.3", "abc123")
         self.mock_github.create_prerelease.return_value = (
             "https://github.com/owner/repo/releases/v2.0.0-rc.3"
         )


### PR DESCRIPTION
## Summary

- **`create_release_branch` (hotfix path)** moved to GitHubHelper — resolves source tag via API, creates branch ref via API
- **`create_rc_tag`** now returns `(tag_name, commit_sha)` — orchestrators use the API-returned SHA for summaries
- **Removed dead code** from GitHelper: `get_head_sha()` and `configure_identity()`
- **GitHelper.create_release_branch`** simplified to HEAD-only (used by CutRelease which always branches from main HEAD)
- All orchestrators now get commit SHAs from API responses, not local HEAD

After this change, no workflow operation depends on local clone state beyond the code checkout on main.

## Test plan

- [x] 123 unit tests pass
- [x] ruff check + format clean
- [ ] Rerun test 7.4 (hotfix with existing branch — should skip to 1.0.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)