### PR TITLE
fix: promote checks out release branch instead of main

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -24,8 +24,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: main
 
       - name: Setup Python
         uses: ./.github/actions/setup-python
@@ -63,8 +61,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: main
 
       - name: Setup Python
         uses: ./.github/actions/setup-python


### PR DESCRIPTION
## Summary
- Removes hardcoded `ref: main` from both checkout steps in promote.yml
- The workflow is dispatched on the release branch, so the default checkout now uses that branch

## Test plan
- [ ] Trigger cut-release and verify promote runs on the release branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)