### PR TITLE
feat: optional commit_id input for cut-release

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -7,6 +7,11 @@ on:
         description: "Release version (e.g., 1.2.0)"
         required: true
         type: string
+      commit_id:
+        description: "Optional 40-char commit SHA on main. Leave blank for main tip."
+        required: false
+        type: string
+        default: ""
 
 concurrency:
   group: cut-release
@@ -27,6 +32,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.commit_id }}
 
       - name: Setup Python
         uses: ./.github/actions/setup-python
@@ -34,4 +41,4 @@ jobs:
       - name: Cut release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: uv run invoke release.cut-release --version "${{ steps.version.outputs.value }}"
+        run: uv run invoke release.cut-release --version "${{ steps.version.outputs.value }}" --commit-id "${{ inputs.commit_id }}"

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -32,8 +32,6 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ inputs.commit_id }}
 
       - name: Setup Python
         uses: ./.github/actions/setup-python

--- a/src/release_tools/cut_release.py
+++ b/src/release_tools/cut_release.py
@@ -49,8 +49,10 @@ class CutRelease:
         version_str = str(version)
         branch = f"release/{version_str}"
 
-        print(f"Creating release branch {branch}...")
-        self._git.create_release_branch(version_str)
+        source_sha = self._commit_id or self._github.get_main_tip_sha()
+
+        print(f"Creating release branch {branch} at {source_sha}...")
+        self._github.create_release_branch_at(version_str, source_sha)
 
         print(f"Creating RC tag v{version_str}-rc.1...")
         tag_name, commit_sha = self._github.create_rc_tag(version_str, branch)

--- a/src/release_tools/cut_release.py
+++ b/src/release_tools/cut_release.py
@@ -11,15 +11,29 @@ from release_tools.version import ReleaseVersionHelper
 class CutRelease:
     """Command to cut a new release candidate."""
 
-    def __init__(self, git: GitHelper, github: GitHubHelper, raw_version: str) -> None:
+    def __init__(
+        self,
+        git: GitHelper,
+        github: GitHubHelper,
+        raw_version: str,
+        commit_id: str | None = None,
+    ) -> None:
         """Initialise with a git helper, GitHub helper, and version string."""
         self._git = git
         self._github = github
         self._raw_version = raw_version
+        self._commit_id = commit_id
 
     def run(self) -> None:
         """Orchestrate cutting a new release candidate."""
         version = ReleaseVersionHelper.parse(self._raw_version)
+
+        if self._commit_id and not self._github.is_ancestor_of_main(self._commit_id):
+            msg = (
+                f"Commit {self._commit_id} is not on main."
+                " Releases must be cut from commits reachable from main."
+            )
+            raise ValueError(msg)
 
         latest = self._git.get_latest_stable_tag()
         ReleaseVersionHelper.check_version_is_higher(version, latest)

--- a/src/release_tools/git.py
+++ b/src/release_tools/git.py
@@ -174,11 +174,6 @@ class GitHelper:
 
         return Version(base_version.major, base_version.minor, highest_patch + 1)
 
-    def create_release_branch(self, version: str) -> None:
-        """Create a ``release/{version}`` branch from HEAD and push it."""
-        branch = self._repo.create_head(f"release/{version}")
-        self._repo.remotes.origin.push(branch.name)
-
     def get_repo_name(self) -> str:
         """Derive the GitHub ``owner/repo`` name from the origin URL."""
         origin_url = self._repo.remotes.origin.url

--- a/src/release_tools/github.py
+++ b/src/release_tools/github.py
@@ -194,6 +194,21 @@ class GitHubHelper:
         comparison = self._repo.compare("main", branch)
         return comparison.ahead_by
 
+    def is_ancestor_of_main(self, sha: str) -> bool:
+        """Return ``True`` if *sha* is on ``main``'s history.
+
+        Uses the GitHub compare API, so no local history is needed.
+        A commit is considered an ancestor when the compare status
+        is ``identical`` or ``behind`` — meaning ``main`` is at or
+        ahead of the commit.  Returns ``False`` when the commit
+        does not exist on the remote.
+        """
+        try:
+            comparison = self._repo.compare("main", sha)
+        except UnknownObjectException:
+            return False
+        return comparison.status in ("identical", "behind")
+
     def find_previous_stable_release(self, exclude_tag: str) -> str | None:
         """Find the previous stable release tag, excluding *exclude_tag*.
 

--- a/src/release_tools/github.py
+++ b/src/release_tools/github.py
@@ -194,6 +194,18 @@ class GitHubHelper:
         comparison = self._repo.compare("main", branch)
         return comparison.ahead_by
 
+    def get_main_tip_sha(self) -> str:
+        """Return the commit SHA at the tip of the ``main`` branch."""
+        return self._repo.get_branch("main").commit.sha
+
+    def create_release_branch_at(self, version: str, sha: str) -> str:
+        """Create ``release/{version}`` at *sha* via the GitHub API.
+
+        Returns the commit SHA the branch points to.
+        """
+        self._repo.create_git_ref(ref=f"refs/heads/release/{version}", sha=sha)
+        return sha
+
     def is_ancestor_of_main(self, sha: str) -> bool:
         """Return ``True`` if *sha* is on ``main``'s history.
 

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -17,8 +17,16 @@ from release_tools.tag_rc import TagRC
 from release_tools.validate_promotion import ValidatePromotion
 
 
-@task(help={"version": "Release version (e.g., 1.2.0 or v1.2.0)"})
-def cut_release(_ctx: Context, version: str) -> None:
+@task(
+    help={
+        "version": "Release version (e.g., 1.2.0 or v1.2.0)",
+        "commit-id": (
+            "Optional 40-char commit SHA on main to cut from."
+            " Defaults to the tip of the default branch."
+        ),
+    }
+)
+def cut_release(_ctx: Context, version: str, commit_id: str | None = None) -> None:
     """Cut a new release candidate.
 
     On GitHub Actions, GH_TOKEN and GITHUB_REPOSITORY are provided
@@ -42,7 +50,7 @@ def cut_release(_ctx: Context, version: str) -> None:
     github = GitHubHelper(Github(token).get_repo(repo_name))
 
     try:
-        CutRelease(git, github, version).run()
+        CutRelease(git, github, version, commit_id or None).run()
     except (ValueError, RuntimeError) as err:
         raise Exit(str(err), code=1) from err
 

--- a/tests/unit/release_tools/test_cut_release.py
+++ b/tests/unit/release_tools/test_cut_release.py
@@ -99,3 +99,26 @@ class TestCutRelease:
         assert github_methods.index("create_prerelease") < github_methods.index(
             "trigger_promotion"
         )
+
+    def test_run_skips_ancestor_check_when_commit_id_not_given(self) -> None:
+        CutRelease(self.mock_git, self.mock_github, "2.0.0").run()
+
+        self.mock_github.is_ancestor_of_main.assert_not_called()
+
+    def test_run_checks_ancestor_when_commit_id_given(self) -> None:
+        self.mock_github.is_ancestor_of_main.return_value = True
+
+        CutRelease(self.mock_git, self.mock_github, "2.0.0", commit_id="a" * 40).run()
+
+        self.mock_github.is_ancestor_of_main.assert_called_once_with("a" * 40)
+        self.mock_git.create_release_branch.assert_called_once_with("2.0.0")
+
+    def test_run_raises_when_commit_not_ancestor_of_main(self) -> None:
+        self.mock_github.is_ancestor_of_main.return_value = False
+
+        with pytest.raises(ValueError, match="not on main"):
+            CutRelease(
+                self.mock_git, self.mock_github, "2.0.0", commit_id="b" * 40
+            ).run()
+
+        self.mock_git.create_release_branch.assert_not_called()

--- a/tests/unit/release_tools/test_cut_release.py
+++ b/tests/unit/release_tools/test_cut_release.py
@@ -21,6 +21,7 @@ class TestCutRelease:
         self.mock_git.get_latest_stable_tag.return_value = Version.parse("1.0.0")
         self.mock_git.get_inflight_release.return_value = None
         self.mock_github.create_rc_tag.return_value = ("v2.0.0-rc.1", "abc123")
+        self.mock_github.get_main_tip_sha.return_value = "main_tip_sha"
         mocker.patch(
             "release_tools.cut_release.ReleaseVersionHelper.parse",
             return_value=Version.parse("2.0.0"),
@@ -32,7 +33,9 @@ class TestCutRelease:
     def test_run_creates_branch_and_tag_when_valid_version(self) -> None:
         CutRelease(self.mock_git, self.mock_github, "2.0.0").run()
 
-        self.mock_git.create_release_branch.assert_called_once_with("2.0.0")
+        self.mock_github.create_release_branch_at.assert_called_once_with(
+            "2.0.0", "main_tip_sha"
+        )
         self.mock_github.create_rc_tag.assert_called_once_with("2.0.0", "release/2.0.0")
 
     def test_run_raises_when_version_not_higher(self, mocker: MockerFixture) -> None:
@@ -111,7 +114,10 @@ class TestCutRelease:
         CutRelease(self.mock_git, self.mock_github, "2.0.0", commit_id="a" * 40).run()
 
         self.mock_github.is_ancestor_of_main.assert_called_once_with("a" * 40)
-        self.mock_git.create_release_branch.assert_called_once_with("2.0.0")
+        self.mock_github.create_release_branch_at.assert_called_once_with(
+            "2.0.0", "a" * 40
+        )
+        self.mock_github.get_main_tip_sha.assert_not_called()
 
     def test_run_raises_when_commit_not_ancestor_of_main(self) -> None:
         self.mock_github.is_ancestor_of_main.return_value = False
@@ -121,4 +127,4 @@ class TestCutRelease:
                 self.mock_git, self.mock_github, "2.0.0", commit_id="b" * 40
             ).run()
 
-        self.mock_git.create_release_branch.assert_not_called()
+        self.mock_github.create_release_branch_at.assert_not_called()

--- a/tests/unit/release_tools/test_git.py
+++ b/tests/unit/release_tools/test_git.py
@@ -227,15 +227,6 @@ class TestGitHelper:
 
         assert result == Version(1, 3, 3)
 
-    def test_create_release_branch_creates_and_pushes_branch(self) -> None:
-        mock_branch = self.mock_repo.create_head.return_value
-        mock_branch.name = "release/1.2.0"
-
-        self.helper.create_release_branch("1.2.0")
-
-        self.mock_repo.create_head.assert_called_once_with("release/1.2.0")
-        self.mock_origin.push.assert_called_once_with("release/1.2.0")
-
     def test_get_repo_name_parses_ssh_url(self) -> None:
         self.mock_origin.url = "git@github.com:owner/repo.git"
 

--- a/tests/unit/release_tools/test_github.py
+++ b/tests/unit/release_tools/test_github.py
@@ -295,6 +295,38 @@ class TestGitHubHelper:
 
         assert result == 0
 
+    # -- is_ancestor_of_main --
+
+    def test_is_ancestor_of_main_true_when_behind(self, mocker: MockerFixture) -> None:
+        self.mock_repo.compare.return_value = mocker.Mock(status="behind")
+
+        assert self.helper.is_ancestor_of_main("abc123") is True
+        self.mock_repo.compare.assert_called_once_with("main", "abc123")
+
+    def test_is_ancestor_of_main_true_when_identical(
+        self, mocker: MockerFixture
+    ) -> None:
+        self.mock_repo.compare.return_value = mocker.Mock(status="identical")
+
+        assert self.helper.is_ancestor_of_main("abc123") is True
+
+    def test_is_ancestor_of_main_false_when_ahead(self, mocker: MockerFixture) -> None:
+        self.mock_repo.compare.return_value = mocker.Mock(status="ahead")
+
+        assert self.helper.is_ancestor_of_main("abc123") is False
+
+    def test_is_ancestor_of_main_false_when_diverged(
+        self, mocker: MockerFixture
+    ) -> None:
+        self.mock_repo.compare.return_value = mocker.Mock(status="diverged")
+
+        assert self.helper.is_ancestor_of_main("abc123") is False
+
+    def test_is_ancestor_of_main_false_when_commit_not_found(self) -> None:
+        self.mock_repo.compare.side_effect = UnknownObjectException(404, {}, {})
+
+        assert self.helper.is_ancestor_of_main("doesnotexist") is False
+
     # -- find_previous_stable_release --
 
     def test_find_previous_stable_release_returns_first_stable_tag(

--- a/tests/unit/release_tools/test_github.py
+++ b/tests/unit/release_tools/test_github.py
@@ -295,6 +295,30 @@ class TestGitHubHelper:
 
         assert result == 0
 
+    # -- get_main_tip_sha --
+
+    def test_get_main_tip_sha_returns_branch_commit_sha(
+        self, mocker: MockerFixture
+    ) -> None:
+        mock_branch = mocker.Mock()
+        mock_branch.commit.sha = "deadbeef"
+        self.mock_repo.get_branch.return_value = mock_branch
+
+        result = self.helper.get_main_tip_sha()
+
+        assert result == "deadbeef"
+        self.mock_repo.get_branch.assert_called_once_with("main")
+
+    # -- create_release_branch_at --
+
+    def test_create_release_branch_at_creates_ref_at_sha(self) -> None:
+        result = self.helper.create_release_branch_at("1.2.0", "abc123")
+
+        assert result == "abc123"
+        self.mock_repo.create_git_ref.assert_called_once_with(
+            ref="refs/heads/release/1.2.0", sha="abc123"
+        )
+
     # -- is_ancestor_of_main --
 
     def test_is_ancestor_of_main_true_when_behind(self, mocker: MockerFixture) -> None:


### PR DESCRIPTION
Adds an optional commit_id input to cut-release.yml so releases can be cut from an earlier commit on main, not just the tip. The workflow passes the SHA to actions/checkout and forwards it to the Python pipeline, which validates (via the GitHub compare API) that the commit is on main before creating the release branch.